### PR TITLE
fix: replace 16 bare excepts with except Exception

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -32,7 +32,7 @@ import asyncio
 
 try:
     from transformers import AutoTokenizer
-except:
+except Exception:
     print("Failed to import AutoTokenizer, local tokenizer is disabled.")
 
 
@@ -175,7 +175,7 @@ class BenchmarkServing:
                 self.detokenize = partial(
                     self.tokenizer.decode, skip_special_tokens=True
                 )
-            except:
+            except Exception:
                 print(
                     "Local tokenizer is not loaded, trying tokenizer interface from server if available."
                 )
@@ -185,7 +185,7 @@ class BenchmarkServing:
                 test_prompt = "tokenizer test message"
                 test_token_ids = self.remote_tokenize(test_prompt)
                 self.remote_detokenize(test_token_ids)
-            except:
+            except Exception:
                 raise Exception(
                     "Tokenizer interface unavailable, please install transformers and set local tokenizer using --tokenizer-path."
                 )
@@ -199,7 +199,7 @@ class BenchmarkServing:
             ), "args.dataset_path should be set to use sharegpt dataset."
             try:
                 self.dataset = ShareGPTDataset(self.config.dataset_path)
-            except:
+            except Exception:
                 raise Exception(
                     "Dataset is not loaded, sharegpt dataset is not supported!"
                 )

--- a/chitu/attn_backend/npu_attn_backend.py
+++ b/chitu/attn_backend/npu_attn_backend.py
@@ -61,7 +61,7 @@ class NpuAttnBackend(RefAttnBackend):
         platform = get_device_name()
         try:
             self.max_aiv_num = core_num_each_platform[platform]
-        except:
+        except Exception:
             raise RuntimeError("Unsupported platform: ", platform)
         self.max_seq_len = StaticTensor(max_nelem=1, dtype=torch.int32, device="npu")
         self.first_seq_id_per_core = StaticTensor(

--- a/chitu/backend.py
+++ b/chitu/backend.py
@@ -1313,7 +1313,7 @@ class Backend:
                     Backend.tokenizer.model.chat_template
                 )
             )
-        except:
+        except Exception:
             logger.exception(f"patch chat template failed, tool call may be incorrect!")
 
         # Initialize tool parser
@@ -1328,7 +1328,7 @@ class Backend:
                     Backend.tokenizer.model.chat_template
                 )
             )
-        except:
+        except Exception:
             logger.exception(f"patch chat template failed, tool call may be incorrect!")
 
         attn_backend_type = Backend._get_attention_backend_type(args)

--- a/chitu/constraint_decode.py
+++ b/chitu/constraint_decode.py
@@ -46,7 +46,7 @@ class ConstraintDecodeManager:
             self.batch_matcher = BatchGrammarMatcher()
             self.states: dict[str, MatcherState] = {}
             self.enabled = True
-        except:
+        except Exception:
             logger.exception("constraint decode initialized failed")
 
     def compile_grammar(

--- a/chitu/dp_token_router.py
+++ b/chitu/dp_token_router.py
@@ -483,7 +483,7 @@ class DPAsyncDataStream(AsyncDataStream):
                     force_full_seq_decode = getattr(
                         Backend.tokenizer, "force_full_seq_decode", False
                     )
-            except:
+            except Exception:
                 force_full_seq_decode = False
 
             if not force_full_seq_decode:

--- a/chitu/encoding_dsv32.py
+++ b/chitu/encoding_dsv32.py
@@ -67,7 +67,7 @@ tool_output_template: str = "\n<result>{content}</result>"
 def to_json(value: Any) -> str:
     try:
         return json.dumps(value, ensure_ascii=False)
-    except:
+    except Exception:
         return json.dumps(value, ensure_ascii=True)
 
 

--- a/chitu/serve/api_server.py
+++ b/chitu/serve/api_server.py
@@ -221,7 +221,7 @@ async def create_chat_completion(
             return JSONResponse(response_dict)
     except HTTPException:
         raise
-    except:
+    except Exception:
         logger.exception("request handle exception")
         with suppress(Exception):
             del user_req

--- a/chitu/tool_call/qwen3_coder_parser.py
+++ b/chitu/tool_call/qwen3_coder_parser.py
@@ -99,7 +99,7 @@ class Qwen3CoderToolParser(SimpleParser):
         arg_type = None
         try:
             arg_type = self.parameters_type[name].properties[arg_name].type
-        except:
+        except Exception:
             logger.exception(f"get arg_type failed {name=} {arg_name=}")
 
         if arg_type == "string":

--- a/chitu/utils.py
+++ b/chitu/utils.py
@@ -369,7 +369,7 @@ class DataSaver:
                     args = get_global_args()
                     model_name = args.models.type
                     model_path = args.models.ckpt_dir
-                except:
+                except Exception:
                     model_name = "unknown"
                     model_path = "unknown"
                 model_dtype = (
@@ -488,7 +488,7 @@ def is_port_available(port: int):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("", port))
             return True
-    except:
+    except Exception:
         return False
 
 

--- a/gen_tmp_requirements_txt.py
+++ b/gen_tmp_requirements_txt.py
@@ -28,7 +28,7 @@ try:
         extras = sys.argv[1].split(",") if sys.argv[1] else []
     else:
         raise ValueError("Too many arguments")
-except:
+except Exception:
     print(
         f"Usage: {sys.argv[0]} [extra1,extra2,...]",
         file=sys.stderr,

--- a/test/test_tool_call.py
+++ b/test/test_tool_call.py
@@ -343,7 +343,7 @@ async def test(
                 f"case {idx} failed: nums mismatch "
                 f"real_nums={real_nums} expected={nums}"
             )
-        except:
+        except Exception:
             logger.exception(f"case {idx} failed {retry=}")
             tested_nums.append(None)
     else:


### PR DESCRIPTION
Replace 16 bare `except:` with `except Exception:` across 11 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.