### PR TITLE
Security: Command Injection via shell=True in NUMA utilities

### DIFF
--- a/chitu/numa_utils.py
+++ b/chitu/numa_utils.py
@@ -23,15 +23,15 @@ def _get_numa_of_gpu(gpu_id: int):
             "Detecting NUMA node near GPU is only supported on NVIDIA GPUs"
         )
 
-    try:
-        # Get PCI bus ID from nvidia-smi
-        result = subprocess.run(
-            f"nvidia-smi --query-gpu=pci.bus_id --format=csv,noheader -i {gpu_id}",
-            shell=True,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        try:
+            # Get PCI bus ID from nvidia-smi
+            result = subprocess.run(
+                ['nvidia-smi', '--query-gpu=pci.bus_id', '--format=csv,noheader', '-i', str(gpu_id)],
+                shell=False,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
         pci_bus_id = result.stdout.strip()
 
         # Convert format (e.g., 00000000:3B:00.0 -> 0000:3b:00.0)


### PR DESCRIPTION
## Summary

Security: Command Injection via shell=True in NUMA utilities

## Problem

**Severity**: `High` | **File**: `chitu/numa_utils.py:L24`

In chitu/numa_utils.py, the subprocess.run call uses shell=True with string formatting for the gpu_id parameter. While gpu_id comes from torch.cuda.current_device() which returns an integer, using shell=True is inherently risky and could lead to command injection if the source changes.

## Solution

Replace shell=True with shell=False and pass arguments as a list: subprocess.run(['nvidia-smi', '--query-gpu=pci.bus_id', '--format=csv,noheader', '-i', str(gpu_id)], capture_output=True, text=True, check=True)

## Changes

- `chitu/numa_utils.py` (modified)