### PR TITLE
Add missing __init__.py for pd_disaggregation package

### DIFF
--- a/chitu/distributed/pd_disaggregation/__init__.py
+++ b/chitu/distributed/pd_disaggregation/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Qingcheng.AI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Prefill-Decode (PD) disaggregation components
+"""


### PR DESCRIPTION
When installing chitu from source with a regular install:
```bash
TORCH_CUDA_ARCH_LIST=8.9 pip install --no-build-isolation . -c <constraints>
```
importing chitu (e.g. python -m chitu) fails with:
```
ModuleNotFoundError: No module named 'chitu.distributed.pd_disaggregation'
```

Traceback originates from chitu/hooks.py:
```
from chitu.distributed.pd_disaggregation.pd_log_utils import ...
```


setup.py uses find_packages(), which only treats a directory as a package if it contains an __init__.py. The directory chitu/distributed/pd_disaggregation/ was missing one. so i add a simple __init__.py to solve this issue.