### PR TITLE
Enhances API key header parsing

### DIFF
--- a/chitu/serve/common.py
+++ b/chitu/serve/common.py
@@ -417,19 +417,27 @@ def parse_api_key_from_headers(
 ) -> str:
     if x_api_key:
         return x_api_key
-    if authorization is None:
+
+    if not authorization:
         return ""
 
     value = authorization.strip()
-    if value == "":
+    if not value:
         return ""
 
-    if not value.lower().startswith("bearer"):
-        raise HTTPException(
-            status_code=400, detail="Authorization header must start with 'Bearer'"
-        )
-    return value[len("bearer") :].strip()
+    scheme, sep, token = value.partition(" ")
 
+    if sep:
+        if scheme.lower() != "bearer":
+            return ""
+        return token.strip()
+
+    # Handle legacy case where the token is provided without a scheme
+    if value.lower().startswith("bearer"):
+        legacy_token = value[6:].strip()  # len("Bearer") == 6
+        return legacy_token
+
+    return ""
 
 def build_chat_template_kwargs(
     enable_thinking: bool,

--- a/test/pytest/test_anthropic_api_params.py
+++ b/test/pytest/test_anthropic_api_params.py
@@ -688,10 +688,16 @@ class TestParseApiKeyFromHeaders:
     def test_missing_headers_returns_empty_string(self):
         assert parse_api_key_from_headers(None, None) == ""
 
-    def test_bearer_without_space_is_accepted_as_empty_key(self):
+    def test_empty_authorization_returns_empty_string(self):
+        assert parse_api_key_from_headers("", None) == ""
+
+    def test_whitespace_authorization_returns_empty_string(self):
+        assert parse_api_key_from_headers("   ", None) == ""
+
+    def test_bearer_without_space_is_ignored(self):
         assert parse_api_key_from_headers("Bearer", None) == ""
 
-    def test_bearer_with_trailing_space_is_accepted_as_empty_key(self):
+    def test_bearer_with_trailing_space_returns_empty(self):
         assert parse_api_key_from_headers("Bearer ", None) == ""
 
     def test_bearer_token_is_extracted(self):
@@ -700,6 +706,32 @@ class TestParseApiKeyFromHeaders:
     def test_bearer_without_space_before_token_is_accepted(self):
         assert parse_api_key_from_headers("Bearerabc", None) == "abc"
 
-    def test_non_bearer_scheme_raises(self):
-        with pytest.raises(HTTPException, match="must start with 'Bearer'"):
-            parse_api_key_from_headers("Basic abc", None)
+    def test_bearer_case_insensitive(self):
+        assert parse_api_key_from_headers("bEaReR abc", None) == "abc"
+
+    def test_multiple_spaces_between_bearer_and_token(self):
+        assert parse_api_key_from_headers("Bearer    abc", None) == "abc"
+
+    def test_token_with_leading_trailing_spaces(self):
+        assert parse_api_key_from_headers("Bearer   abc   ", None) == "abc"
+
+    def test_token_with_internal_spaces(self):
+        assert parse_api_key_from_headers("Bearer abc def", None) == "abc def"
+
+    def test_non_bearer_scheme_returns_empty(self):
+        assert parse_api_key_from_headers("Basic abc", None) == ""
+
+    def test_authorization_without_scheme_returns_empty(self):
+        assert parse_api_key_from_headers("12345678", None) == ""
+
+    def test_bearer_with_newlines_and_tabs(self):
+        assert parse_api_key_from_headers("\tBearer abc\n", None) == "abc"
+
+    def test_unicode_token(self):
+        assert parse_api_key_from_headers("Bearer 你好abc", None) == "你好abc"
+
+    def test_x_api_key_overrides_invalid_bearer(self):
+        assert parse_api_key_from_headers("Basic abc", "x-key") == "x-key"
+
+    def test_x_api_key_overrides_even_empty_bearer(self):
+        assert parse_api_key_from_headers("Bearer", "x-key") == "x-key"


### PR DESCRIPTION
Enhances the `parse_api_key_from_headers` function to improve robustness and flexibility when extracting API keys from `Authorization` headers.

This update modifies the parsing logic to handle a wider variety of header formats more gracefully. Previously, the function would raise an `HTTPException` for malformed headers or non-bearer schemes. This change shifts the behavior to consistently return an empty string when a valid bearer token cannot be parsed, allowing downstream logic to manage authentication failures more flexibly without immediate exceptions.

Key improvements include:
- More robust parsing of `Authorization` header values, accommodating various whitespace patterns and case-insensitive 'Bearer' schemes.
- Supports legacy formats where 'Bearer' might be directly concatenated with the token without a space.
- Gracefully returns an empty string for invalid, empty, or non-bearer authorization schemes, rather than raising an `HTTPException`.
- Ensures the `x_api_key` header continues to take precedence over the `Authorization` header, even if the latter is malformed or empty.