### PR TITLE
docs: add English comments to core inference modules

### DIFF
--- a/chitu/attn_backend/base.py
+++ b/chitu/attn_backend/base.py
@@ -38,18 +38,18 @@ class AttnBackend(abc.ABC):
     Chitu supports multiple attention implementations that are selected at
     runtime based on GPU architecture and model type:
 
-    - ``FlashAttnBackend`` — FlashAttention 2/3 for standard attention.
-    - ``FlashMLABackend`` — Multi-head Latent Attention (MLA) for DeepSeek-V3/V4.
-    - ``FlashInferBackend`` — FlashInfer's optimized paged-attention kernels.
-    - ``HopperMixedBackend`` — Mixed-precision attention for Hopper (SM90) GPUs.
-    - ``HybridAttnBackend`` — Selects the best backend per operation (prefill vs decode).
-    - ``TritonAttnBackend`` — Triton-based attention (portable across accelerators).
-    - ``NpuAttnBackend`` — Ascend NPU attention implementation.
-    - ``RefAttnBackend`` — Pure PyTorch reference implementation (CPU/Muxi).
+    - ``FlashAttnBackend`` — FlashAttention 2/3.
+    - ``FlashMLABackend`` — FlashMLA for MLA in DeepSeek-V3/V4 and similar models.
+    - ``FlashInferBackend`` — FlashInfer.
+    - ``HybridAttnBackend`` — Selects a better backend per operation.
+    - ``TritonAttnBackend`` — Triton-based implementation.
+    - ``NpuAttnBackend`` — Ascend NPU implementation.
+    - ``RefAttnBackend`` — Pure PyTorch reference implementation.
 
     Each backend implements two paths:
     - ``__call__`` — the actual attention computation (read KV from cache,
-      compute QK scores, apply softmax, compute weighted V sum, write KV to cache).
+      compute QK scores, apply softmax, compute weighted V sum, optionally write
+      KV to cache).
     - ``prepare_metadata_for_*`` — set up metadata (e.g. page tables) before
       prefill or decode steps.
     """

--- a/chitu/attn_backend/base.py
+++ b/chitu/attn_backend/base.py
@@ -35,22 +35,16 @@ logger = getLogger(__name__)
 class AttnBackend(abc.ABC):
     """Abstract interface for attention operator backends.
 
-    Chitu supports multiple attention implementations that are selected at
-    runtime based on GPU architecture, model type, and configuration:
-
-    - ``FlashAttnBackend`` — FlashAttention 2/3.
-    - ``FlashMLABackend`` — FlashMLA for MLA-style attention.
-    - ``FlashInferBackend`` — FlashInfer.
-    - ``HybridAttnBackend`` — Selects a backend per operation.
-    - ``TritonAttnBackend`` — Triton-based implementation.
-    - ``NpuAttnBackend`` — Ascend NPU implementation.
-    - ``RefAttnBackend`` — Pure PyTorch reference implementation.
+    Chitu supports several attention implementations selected at runtime based
+    on accelerator architecture, model type, and configuration, including
+    FlashAttention, FlashMLA, FlashInfer, Triton, hybrid backends, NPU backends,
+    and pure-PyTorch reference implementations.
 
     Each backend implements two paths:
-    - ``__call__`` — the actual attention computation (read KV from cache,
-      compute QK scores, apply softmax, compute weighted V sum, optionally write
-      KV to cache).
-    - ``prepare_metadata_for_*`` — set up metadata before prefill or decode steps.
+    - ``__call__`` — the actual attention computation. If ``k`` and ``v`` are
+      provided, the call may also append them to the KV cache.
+    - ``prepare_metadata_for_*`` — set up backend-specific metadata before
+      prefill or decode steps.
     """
 
     def __init__(self, *, qk_nope_head_dim: Optional[int] = None):

--- a/chitu/attn_backend/base.py
+++ b/chitu/attn_backend/base.py
@@ -33,8 +33,25 @@ logger = getLogger(__name__)
 
 
 class AttnBackend(abc.ABC):
-    """
-    Interface class for all attention implementations
+    """Abstract interface for attention operator backends.
+
+    Chitu supports multiple attention implementations that are selected at
+    runtime based on GPU architecture and model type:
+
+    - ``FlashAttnBackend`` — FlashAttention 2/3 for standard attention.
+    - ``FlashMLABackend`` — Multi-head Latent Attention (MLA) for DeepSeek-V3/V4.
+    - ``FlashInferBackend`` — FlashInfer's optimized paged-attention kernels.
+    - ``HopperMixedBackend`` — Mixed-precision attention for Hopper (SM90) GPUs.
+    - ``HybridAttnBackend`` — Selects the best backend per operation (prefill vs decode).
+    - ``TritonAttnBackend`` — Triton-based attention (portable across accelerators).
+    - ``NpuAttnBackend`` — Ascend NPU attention implementation.
+    - ``RefAttnBackend`` — Pure PyTorch reference implementation (CPU/Muxi).
+
+    Each backend implements two paths:
+    - ``__call__`` — the actual attention computation (read KV from cache,
+      compute QK scores, apply softmax, compute weighted V sum, write KV to cache).
+    - ``prepare_metadata_for_*`` — set up metadata (e.g. page tables) before
+      prefill or decode steps.
     """
 
     def __init__(self, *, qk_nope_head_dim: Optional[int] = None):

--- a/chitu/attn_backend/base.py
+++ b/chitu/attn_backend/base.py
@@ -36,12 +36,12 @@ class AttnBackend(abc.ABC):
     """Abstract interface for attention operator backends.
 
     Chitu supports multiple attention implementations that are selected at
-    runtime based on GPU architecture and model type:
+    runtime based on GPU architecture, model type, and configuration:
 
     - ``FlashAttnBackend`` — FlashAttention 2/3.
-    - ``FlashMLABackend`` — FlashMLA for MLA in DeepSeek-V3/V4 and similar models.
+    - ``FlashMLABackend`` — FlashMLA for MLA-style attention.
     - ``FlashInferBackend`` — FlashInfer.
-    - ``HybridAttnBackend`` — Selects a better backend per operation.
+    - ``HybridAttnBackend`` — Selects a backend per operation.
     - ``TritonAttnBackend`` — Triton-based implementation.
     - ``NpuAttnBackend`` — Ascend NPU implementation.
     - ``RefAttnBackend`` — Pure PyTorch reference implementation.
@@ -50,8 +50,7 @@ class AttnBackend(abc.ABC):
     - ``__call__`` — the actual attention computation (read KV from cache,
       compute QK scores, apply softmax, compute weighted V sum, optionally write
       KV to cache).
-    - ``prepare_metadata_for_*`` — set up metadata (e.g. page tables) before
-      prefill or decode steps.
+    - ``prepare_metadata_for_*`` — set up metadata before prefill or decode steps.
     """
 
     def __init__(self, *, qk_nope_head_dim: Optional[int] = None):

--- a/chitu/backend.py
+++ b/chitu/backend.py
@@ -103,6 +103,7 @@ class BackendState(Enum):
     Terminated:
         All ranks have stopped.  The main loop exits.
     """
+
     Running = 1
     Terminating = 2  # All tasks done, but rank 0 should tell others to terminate
     Terminated = 3
@@ -119,6 +120,9 @@ class Backend:
     - KV caches and per-DP-rank cache managers.
     - Schedulers (one per DP rank) and the Executor.
     - MoE weight accessor for dynamic expert load-balancing.
+
+    Some components are attached by later initialization steps outside
+    ``Backend.build()``.
 
     The build order in ``Backend.build()`` is:
     1. Init distributed environment (NCCL/GLOO, parallel groups).

--- a/chitu/backend.py
+++ b/chitu/backend.py
@@ -92,12 +92,42 @@ logger = getLogger(__name__)
 
 
 class BackendState(Enum):
+    """Global state machine for the inference backend.
+
+    Running:
+        Normal operation — accepting and processing requests.
+    Terminating:
+        A termination signal has been received.  The backend drains in-flight
+        requests but does not accept new ones.  Once all tasks are finished,
+        rank 0 broadcasts the Terminated state to all workers.
+    Terminated:
+        All ranks have stopped.  The main loop exits.
+    """
     Running = 1
     Terminating = 2  # All tasks done, but rank 0 should tell others to terminate
     Terminated = 3
 
 
 class Backend:
+    """Static registry and lifecycle manager for the inference backend.
+
+    Backend is a **namespace class** (all attributes are class-level, never
+    instantiated).  It holds singleton references to every long-lived component
+    in the system:
+
+    - Model, tokenizer, and formatter (built once at startup).
+    - KV caches and per-DP-rank cache managers.
+    - Schedulers (one per DP rank) and the Executor.
+    - MoE weight accessor for dynamic expert load-balancing.
+
+    The build order in ``Backend.build()`` is:
+    1. Init distributed environment (NCCL/GLOO, parallel groups).
+    2. Init tokenizer, processor, formatter.
+    3. Build KV caches and per-DP-rank cache managers.
+    4. Create and load the model.
+    5. Register MoE weight accessor (if the model supports it).
+    """
+
     # init once
     model = None
     tokenizer = None
@@ -157,7 +187,17 @@ class Backend:
     def register_moe_layer_experts(
         layer_id: int, experts_module: QuantizedMoeExpertsBase
     ) -> None:
-        """Register the experts module for a specific layer and auto-wire accessor."""
+        """Register a layer's MoE experts module for dynamic load-balancing.
+
+        Called by each transformer layer during model construction.  The first
+        call auto-creates an ``ExpertParamAccessor`` that can read and write
+        individual expert parameters by slot index, enabling the MoE load
+        planner to migrate experts between EP ranks via P2P transfer.
+
+        Args:
+            layer_id: The transformer layer index (0-based).
+            experts_module: The quantized experts module for that layer.
+        """
         Backend._moe_experts_by_layer[int(layer_id)] = experts_module
         # Build and register accessor lazily on first registration
         if Backend.moe_weight_accessor is None:
@@ -995,6 +1035,19 @@ class Backend:
 
     @staticmethod
     def _load_hf_checkpoint_layerwise(model, args):
+        """Load HuggingFace-format checkpoints one layer at a time.
+
+        Instead of loading the entire checkpoint into CPU RAM (which can exceed
+        hundreds of GB for MoE models), this method loads each transformer
+        layer's weights independently, moves them to GPU, and frees the CPU
+        buffer before loading the next layer.  Non-layer weights (embeddings,
+        final norm, lm_head) are loaded first; then layers are iterated in
+        global layer order, with PP-sliced ranks each loading only their
+        assigned layer range.
+
+        For models with multi-token prediction (MTP), a separate pass handles
+        the MTP-specific layers at the end.
+        """
 
         key_filter = Backend._build_hf_key_filter(args)
 
@@ -1232,6 +1285,17 @@ def load_state_dict(
     prefix: str = "",
     prefix_list: list[str] = None,
 ):
+    """Load model weights from safetensors files in a HuggingFace checkpoint directory.
+
+    Supports:
+    - Loading a subset of keys via ``prefix`` (single prefix match).
+    - Loading from additional prefix lists via ``prefix_list``.
+    - Filtering keys with a caller-supplied ``key_filter`` callback.
+    - ``skip_preprocess`` mode: each rank loads only its own shard
+      (``model.rank{rank}.safetensors``).
+
+    Returns a dict mapping parameter names to CPU tensors.
+    """
     if not skip_preprocess:
         path = os.path.join(hf_ckpt_path, "*.safetensors")
     else:

--- a/chitu/backend.py
+++ b/chitu/backend.py
@@ -97,9 +97,8 @@ class BackendState(Enum):
     Running:
         Normal operation — accepting and processing requests.
     Terminating:
-        A termination signal has been received.  The backend drains in-flight
-        requests but does not accept new ones.  Once all tasks are finished,
-        rank 0 broadcasts the Terminated state to all workers.
+        A termination signal has been received.  The serving loop drains
+        in-flight requests before moving the backend to Terminated.
     Terminated:
         All ranks have stopped.  The main loop exits.
     """
@@ -1293,8 +1292,8 @@ def load_state_dict(
 
     Supports:
     - Loading a subset of keys via ``prefix`` (single prefix match).
-    - Loading from additional prefix lists via ``prefix_list``.
-    - Filtering keys with a caller-supplied ``key_filter`` callback.
+    - Loading extra keys via ``prefix_list``.
+    - Filtering normally loaded keys with a caller-supplied ``key_filter`` callback.
     - ``skip_preprocess`` mode: each rank loads only its own shard
       (``model.rank{rank}.safetensors``).
 

--- a/chitu/chitu_main.py
+++ b/chitu/chitu_main.py
@@ -1394,8 +1394,8 @@ def _update_tasks_preferred_dp_rank():
     1. **Prefix cache hit rate** — how many of the request's prompt tokens
        are already cached on each DP rank.  Higher cache hits mean fewer
        tokens to recompute during prefill, reducing latency.
-    2. **Current load** — the number of in-flight decode tasks on each DP
-       rank.  Load is penalized to avoid overloading a single rank.
+    2. **Current load** — the number of in-flight tasks on each DP rank.
+       Load is penalized to avoid overloading a single rank.
 
     The final score per rank is:
         score = cache_hit_rate * hit_rate_weight

--- a/chitu/chitu_main.py
+++ b/chitu/chitu_main.py
@@ -118,11 +118,10 @@ def init_cache_static():
 def _deepseek_v4_compressed_ratio_from_manager_name(manager_name: str) -> Optional[int]:
     """Extract the compression ratio from a DeepSeek-V4 KV cache manager name.
 
-    DeepSeek-V4 uses compressed key-value caches (CSA and HCA) to reduce memory
-    footprint.  The manager name encodes the compression ratio:
-        - "compressed_csa" → 4x  (compressed sliding-window attention)
-        - "compressed_hca" → 128x (highly compressed attention)
-        - "compressed_N"   → Nx  (generic compressed cache)
+    DeepSeek-V4 compressed cache manager names encode the compression ratio:
+        - "compressed_csa" -> 4x
+        - "compressed_hca" -> 128x
+        - "compressed_<ratio>" -> that ratio
 
     Returns None if the manager does not represent a compressed cache.
     """
@@ -456,15 +455,14 @@ def _auto_set_deepseek_v4_num_blocks_after_warmup(
 ):
     """Resize DeepSeek-V4 KV cache blocks after warmup based on memory budget.
 
-    DeepSeek-V4 has multiple KV cache groups (main, compressed CSA, compressed
-    HCA) that must be jointly sized.  This solver uses a binary search over the
-    effective logical sequence length to find the largest per-group block
-    allocation that fits within the GPU memory budget.
+    DeepSeek-V4 has multiple KV cache groups (main and compressed groups) that
+    must be jointly sized.  This solver uses a binary search over the effective
+    logical sequence length to find the largest per-group block allocation that
+    fits within the GPU memory budget.
 
-    The solver treats sliding-window groups as fixed at one page per hot
-    request, and sizes compressed groups proportionally to the effective
-    sequence length.  Results are reduced across all ranks to ensure
-    consistency.
+    Fixed-size groups are kept at their capacity, compressed groups are sized
+    proportionally to the effective sequence length, and results are reduced
+    across all ranks to ensure consistency.
     """
     reserve_bytes = 512 << 20
     cache_groups = {}
@@ -909,7 +907,7 @@ def _emit_observed_op_impl_summary_after_warmup():
 
 
 def _warmup_via_taskpool(args):
-    """Warm up the inference engine by running mock requests through the full scheduler → executor pipeline.
+    """Warm up the inference engine by running mock requests through the full scheduler -> executor pipeline.
 
     This is the standard warmup path for standalone (non-PD-disaggregated)
     deployments.  It exercises both prefill and decode phases using the real
@@ -917,9 +915,9 @@ def _warmup_via_taskpool(args):
     and sequence lengths.  After warmup completes, the MoE load planner is
     switched from warmup to production mode.
 
-    The warmup runs ``max_batch_size`` requests, each with a sequence length
-    derived from ``prefill_chunk_size``.  Rank 0 drives the loop; other ranks
-    follow via the executor until termination is signaled.
+    The warmup starts ``max_batch_size`` mock requests with prompt length derived
+    from ``prefill_chunk_size``.  Rank 0 drives the loop; other ranks follow via
+    the executor until termination is signaled.
     """
 
     rank = torch.distributed.get_rank()
@@ -1077,15 +1075,16 @@ def _warmup_backend_direct(
     """Warm up the model backend directly, bypassing the scheduler.
 
     This is used in two scenarios:
-    1. **PD disaggregation** — decode-only workers skip prefill and prefill-only
-       workers skip decode, so each role only warms the operators it actually runs.
+    1. **PD disaggregation** — decode-only workers skip model prefill and
+       prefill-only workers skip decode, so each role only warms the operators
+       it actually runs.
     2. **Full warmup** — after the KV cache is resized, the engine runs decode
        steps at every possible batch size (descending from ``local_max_bs`` to 1)
        to capture CUDA graphs and JIT-compile all operator variants.
 
-    The warmup creates mock requests with random token IDs, runs a single
-    prefill step, then runs ``decode_steps`` decode steps (optionally descending
-    batch size by ``bs_descend`` each step).
+    The warmup prepares cache state for mock requests, optionally runs one
+    prefill model call, then optionally runs ``decode_steps`` decode model calls
+    with descending batch size controlled by ``bs_descend``.
     """
     logger.info(
         f"Starting local backend warmup (direct) with local max batch size {local_max_bs}..."
@@ -1514,10 +1513,10 @@ def chitu_run_main_rank():
 
     The step is split into three phases:
 
-    1. **Schedule** — each DP-rank scheduler selects ready prefill and decode
-       tasks.  Prefill tasks are first assigned preferred DP ranks via
-       ``_update_tasks_preferred_dp_rank`` (balancing cache-hit rate and per-rank
-       load).  Decode tasks follow, filling remaining budget.
+    1. **Schedule** — schedulers select ready prefill or decode tasks. In DP,
+       tasks are assigned to preferred DP ranks for a better load and prefix
+       cache hit. In DP, also ensure either all the ranks are running prefill or
+       all the ranks are running decode.
 
     2. **Run** — the Executor dispatches task metadata across TP/PP/DP ranks,
        runs the model (prefill or decode), samples tokens, and collects results.
@@ -1525,6 +1524,7 @@ def chitu_run_main_rank():
     3. **Update TaskPool** — completed tasks are removed, running tasks are
        updated with new tokens and status changes.
     """
+    global _last_step_task_type
     for scheduler in Backend.schedulers:
         scheduler.prepare_for_schedule()
     if Backend.args.infer.dp_size == 1:

--- a/chitu/chitu_main.py
+++ b/chitu/chitu_main.py
@@ -922,6 +922,8 @@ def _warmup_via_taskpool(args):
     follow via the executor until termination is signaled.
     """
 
+    rank = torch.distributed.get_rank()
+
     # Turn ON MoE planner warmup mode on all ranks
     planner = get_moe_load_planner()
     if planner is not None:

--- a/chitu/chitu_main.py
+++ b/chitu/chitu_main.py
@@ -1524,6 +1524,8 @@ def chitu_run_main_rank():
     3. **Update TaskPool** — completed tasks are removed, running tasks are
        updated with new tokens and status changes.
     """
+
+    # 1. Schedule
     global _last_step_task_type
     for scheduler in Backend.schedulers:
         scheduler.prepare_for_schedule()

--- a/chitu/chitu_main.py
+++ b/chitu/chitu_main.py
@@ -116,6 +116,16 @@ def init_cache_static():
 
 
 def _deepseek_v4_compressed_ratio_from_manager_name(manager_name: str) -> Optional[int]:
+    """Extract the compression ratio from a DeepSeek-V4 KV cache manager name.
+
+    DeepSeek-V4 uses compressed key-value caches (CSA and HCA) to reduce memory
+    footprint.  The manager name encodes the compression ratio:
+        - "compressed_csa" → 4x  (compressed sliding-window attention)
+        - "compressed_hca" → 128x (highly compressed attention)
+        - "compressed_N"   → Nx  (generic compressed cache)
+
+    Returns None if the manager does not represent a compressed cache.
+    """
     if manager_name == "compressed_csa":
         return 4
     if manager_name == "compressed_hca":
@@ -133,6 +143,21 @@ def _deepseek_v4_compressed_blocks_for_seq_len(
     block_size: int,
     num_reqs: int,
 ) -> int:
+    """Compute the number of compressed KV cache blocks needed for a given sequence length.
+
+    DeepSeek-V4's compressed attention stores tokens at reduced resolution.
+    For example, with a 128x compression ratio, every 128 tokens map to a single
+    compressed token.  The compressed tokens are then stored in paged blocks.
+
+    Args:
+        seq_len: Logical sequence length (uncompressed).
+        ratio: Compression ratio (e.g. 4 for CSA, 128 for HCA).
+        block_size: Number of compressed tokens per physical block.
+        num_reqs: Number of concurrent requests.
+
+    Returns:
+        Total number of compressed blocks required across all requests.
+    """
     compressed_len = max(0, int(seq_len)) // int(ratio)
     if compressed_len == 0:
         return 0
@@ -145,6 +170,15 @@ def _direct_warmup_target_lens(
     bs_descend: int,
     skip_model_decode: bool,
 ) -> list[int]:
+    """Build a list of target token lengths for direct warmup requests.
+
+    Direct warmup bypasses the scheduler and drives the model directly with mock
+    requests.  Each request starts with 1 prefill token.  If decode is enabled,
+    the warmup simulates multiple decode steps where each step advances the
+    sequence by ``mtp_size`` tokens (for multi-token prediction models).
+    Later decode steps use progressively smaller batch sizes when ``bs_descend``
+    is non-zero.
+    """
     local_max_bs = int(local_max_bs)
     if local_max_bs <= 0:
         return []
@@ -420,6 +454,18 @@ def _auto_set_deepseek_v4_num_blocks_after_warmup(
     args,
     paged_caches,
 ):
+    """Resize DeepSeek-V4 KV cache blocks after warmup based on memory budget.
+
+    DeepSeek-V4 has multiple KV cache groups (main, compressed CSA, compressed
+    HCA) that must be jointly sized.  This solver uses a binary search over the
+    effective logical sequence length to find the largest per-group block
+    allocation that fits within the GPU memory budget.
+
+    The solver treats sliding-window groups as fixed at one page per hot
+    request, and sizes compressed groups proportionally to the effective
+    sequence length.  Results are reduced across all ranks to ensure
+    consistency.
+    """
     reserve_bytes = 512 << 20
     cache_groups = {}
     for name, cache in paged_caches.items():
@@ -863,7 +909,18 @@ def _emit_observed_op_impl_summary_after_warmup():
 
 
 def _warmup_via_taskpool(args):
-    rank = torch.distributed.get_rank()
+    """Warm up the inference engine by running mock requests through the full scheduler → executor pipeline.
+
+    This is the standard warmup path for standalone (non-PD-disaggregated)
+    deployments.  It exercises both prefill and decode phases using the real
+    scheduler and executor, capturing CUDA graphs at representative batch sizes
+    and sequence lengths.  After warmup completes, the MoE load planner is
+    switched from warmup to production mode.
+
+    The warmup runs ``max_batch_size`` requests, each with a sequence length
+    derived from ``prefill_chunk_size``.  Rank 0 drives the loop; other ranks
+    follow via the executor until termination is signaled.
+    """
 
     # Turn ON MoE planner warmup mode on all ranks
     planner = get_moe_load_planner()
@@ -1015,6 +1072,19 @@ def _warmup_backend_direct(
     skip_model_prefill: bool = False,
     skip_model_decode: bool = False,
 ):
+    """Warm up the model backend directly, bypassing the scheduler.
+
+    This is used in two scenarios:
+    1. **PD disaggregation** — decode-only workers skip prefill and prefill-only
+       workers skip decode, so each role only warms the operators it actually runs.
+    2. **Full warmup** — after the KV cache is resized, the engine runs decode
+       steps at every possible batch size (descending from ``local_max_bs`` to 1)
+       to capture CUDA graphs and JIT-compile all operator variants.
+
+    The warmup creates mock requests with random token IDs, runs a single
+    prefill step, then runs ``decode_steps`` decode steps (optionally descending
+    batch size by ``bs_descend`` each step).
+    """
     logger.info(
         f"Starting local backend warmup (direct) with local max batch size {local_max_bs}..."
     )
@@ -1115,6 +1185,24 @@ def _warmup_backend_direct(
 
 
 def warmup_engine(args):
+    """Three-phase engine warmup: light run → KV resize → full CUDA graph capture.
+
+    Phase 1 (light run):
+        Run one forward pass at a representative batch size to trigger JIT
+        compilation and estimate peak GPU memory.  Routes through either
+        ``_warmup_via_taskpool`` (standalone) or ``_warmup_backend_direct``
+        (PD disaggregation).
+
+    Phase 2 (KV reallocation):
+        Resize KV cache blocks based on measured memory usage, reclaiming
+        any excess for the CUDA allocator or growing if room permits.
+        Captured CUDA graphs are invalidated and re-captured after resizing.
+
+    Phase 3 (full warmup, optional):
+        If ``full_warmup`` is enabled, run decode steps at every batch size
+        from ``local_max_bs`` down to 1.  This ensures all CUDA graphs are
+        captured and all operator variants are tuned before serving traffic.
+    """
     # Router 进程不做 warmup
     if args.multi_inst.router.is_router:
         return
@@ -1298,10 +1386,23 @@ def chitu_init(args):
 
 
 def _update_tasks_preferred_dp_rank():
-    """Update the preferred DP rank for each schedulable but unscheduled prefill task.
-    The preferred DP rank selection considers:
-        - Prefix cache hit rate
-        - Load of each DP rank
+    """Assign a preferred DP rank to each unscheduled prefill task.
+
+    In a multi-DP deployment, each request can be routed to any DP rank.
+    This function picks the best rank by balancing two factors:
+
+    1. **Prefix cache hit rate** — how many of the request's prompt tokens
+       are already cached on each DP rank.  Higher cache hits mean fewer
+       tokens to recompute during prefill, reducing latency.
+    2. **Current load** — the number of in-flight decode tasks on each DP
+       rank.  Load is penalized to avoid overloading a single rank.
+
+    The final score per rank is:
+        score = cache_hit_rate * hit_rate_weight
+              - running_tasks * running_penalty_weight
+
+    The weights are configurable via ``dp_prefix_caching_hit_rate_weight``
+    and ``dp_prefix_caching_running_penalty_weight``.
     """
     args = get_global_args()
     dp_size = int(args.infer.dp_size)
@@ -1407,8 +1508,21 @@ def _collect_ready_task_ids_by_dp(task_type: TaskType) -> list[list[str]]:
 
 @torch.inference_mode()
 def chitu_run_main_rank():
-    # 1. Schedule
-    global _last_step_task_type
+    """Execute one inference step on the main (rank-0) process.
+
+    The step is split into three phases:
+
+    1. **Schedule** — each DP-rank scheduler selects ready prefill and decode
+       tasks.  Prefill tasks are first assigned preferred DP ranks via
+       ``_update_tasks_preferred_dp_rank`` (balancing cache-hit rate and per-rank
+       load).  Decode tasks follow, filling remaining budget.
+
+    2. **Run** — the Executor dispatches task metadata across TP/PP/DP ranks,
+       runs the model (prefill or decode), samples tokens, and collects results.
+
+    3. **Update TaskPool** — completed tasks are removed, running tasks are
+       updated with new tokens and status changes.
+    """
     for scheduler in Backend.schedulers:
         scheduler.prepare_for_schedule()
     if Backend.args.infer.dp_size == 1:
@@ -1546,6 +1660,13 @@ _last_alloc_retries = 0
 
 
 def check_alloc_retries():
+    """Log a warning if PyTorch's CUDA allocator had to retry allocations.
+
+    Retried allocations indicate memory fragmentation — the allocator had to
+    free cached memory and re-request it from CUDA.  Frequent retries degrade
+    performance significantly and usually mean ``memory_utilization`` is set too
+    high for the current workload.
+    """
     global _last_alloc_retries
     cur_alloc_retries = torch.cuda.memory_stats(torch.cuda.current_device())[
         "num_alloc_retries"

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -81,9 +81,8 @@ class TasksDispatcher(ABC):
     for later stages).
 
     General workflow:
-    1. ``Executor.step()`` calls ``dispatch_metadata`` on each dispatcher in
-       depth-first order (pipe → PCP → TP → DP).  Each dispatcher sends the
-       task metadata to its sibling ranks.
+    1. ``Executor.step()`` calls ``dispatch_metadata`` on each dispatcher.
+       Each dispatcher sends the task metadata to its sibling ranks.
     2. For each model input tensor:
        a. On the source rank (TP0/PCP0/PP stage 0), the Executor generates the
           payload (token IDs for first PP stage, hidden states otherwise).
@@ -91,12 +90,6 @@ class TasksDispatcher(ABC):
        c. On target ranks, ``recv_payload`` receives the tensor.
     3. Every rank runs the model forward pass independently.
     4. Results flow backward (PP last → PP first, DP workers → DP main rank).
-
-    When combining multiple parallelism strategies, dispatchers are chained:
-    the executor prepends them in order so that outer dispatchers (PP) wrap
-    inner ones (TP, DP).  Only ranks that are "main" for a given parallelism
-    level participate in its dispatcher communication.  See ``Executor.step()``
-    for the dispatch ordering.
     """
 
     def __init__(
@@ -265,13 +258,14 @@ class TasksDispatcher(ABC):
 
 
 class PipeDispatcher(TasksDispatcher):
-    """Pipeline Parallelism (PP) dispatcher using ZMQ PUSH/PULL point-to-point links.
+    """Pipeline Parallelism (PP) dispatcher using point-to-point links.
 
-    Each PP stage sends hidden states to the next stage via ZMQ.  The protocol
-    automatically selects IPC (shared memory) when adjacent stages reside on the
-    same node, or TCP when they are on different nodes.  Metadata (task IDs,
-    sequence lengths, slot indices) is serialized via msgpack and forwarded
-    through the pipeline alongside the tensor payloads.
+    Each PP stage sends hidden states to the next stage.  Metadata and tensor
+    payloads use different communication channels: metadata is serialized via
+    msgpack and forwarded through ZMQ PUSH/PULL sockets, while tensor payloads
+    are transferred with ``torch.distributed`` point-to-point operations.  The
+    ZMQ protocol automatically selects IPC (shared memory) when adjacent stages
+    reside on the same node, or TCP when they are on different nodes.
 
     Only the first TP rank and first PCP rank within each PP stage participates
     in metadata dispatch; tensor payloads use NCCL send/recv for efficiency.
@@ -1128,10 +1122,9 @@ class Executor:
 
         This is the heart of the executor.  A step proceeds through these phases:
 
-        1. **Metadata dispatch** — each dispatcher (PP → PCP → TP → DP) serializes
-           task metadata and sends it to its sibling ranks via ZMQ.  After
-           dispatch, every rank that participates in the step has a local copy
-           of the task descriptors.
+        1. **Metadata dispatch** — each dispatcher serializes task metadata and
+           sends it to its sibling ranks via ZMQ.  After dispatch, every rank
+           that participates in the step has a local copy of the task descriptors.
 
         2. **Special payload handling** — ``TerminateBackend`` sets the backend
            state to Terminated; ``EndTask`` cleans up finished tasks (KV cache
@@ -1240,6 +1233,7 @@ class Executor:
            to produce next-token predictions.
         7. Notifies the KV transfer hook after prefill for PD disaggregation.
         """
+        if tasks.payload_type == SerializedPackedTasksPayloadType.Empty:
             if not self.is_pp_first_stage:
                 self._collect_task_and_pp_results(tasks)
             return
@@ -1364,10 +1358,9 @@ class Executor:
     def prefill_step(self, tasks: PackedTasksBase) -> torch.Tensor:
         """Run a single prefill forward pass.
 
-        Prefill processes the prompt tokens of newly scheduled requests in
-        parallel.  Each request's full prompt is fed through the model at once,
-        producing the KV cache entries for all prompt tokens and the hidden
-        state of the last token (used for first-token sampling).
+        Prefill processes prompt tokens of newly scheduled requests in parallel,
+        producing KV cache entries and the hidden state of the last token used
+        for first-token sampling.
 
         Steps:
         1. Prepare KV caches (allocate blocks, set sequence lengths).
@@ -1377,6 +1370,7 @@ class Executor:
         5. Send output hidden states to the next PP stage.
         6. Collect prompt token metrics for Prometheus.
         """
+        is_empty_step = tasks.num_tasks == 0
         if not is_empty_step:
             for cache in Backend.cache_dict.values():
                 cache.prepare_cache_prefill(tasks)
@@ -1446,6 +1440,7 @@ class Executor:
         4. Call ``Backend.model.decode()``.
         5. Send the output to the next PP stage.
         """
+        if tasks.num_tasks == 0:
             is_empty_step = True
         if not is_empty_step:
             # Ensure KV cache is present for PD decode-only before updating CacheManager state.

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -268,7 +268,8 @@ class PipeDispatcher(TasksDispatcher):
     reside on the same node, or TCP when they are on different nodes.
 
     Only the first TP rank and first PCP rank within each PP stage participates
-    in metadata dispatch; tensor payloads use NCCL send/recv for efficiency.
+    in metadata dispatch; tensor payloads use torch.distributed send/recv for
+    efficiency.
     """
 
     def __init__(
@@ -462,13 +463,13 @@ class PipeDispatcher(TasksDispatcher):
 
 
 class TensorDispatcher(TasksDispatcher):
-    """TP and PCP task dispatcher using ZMQ ROUTER/DEALER + NCCL broadcast.
+    """TP and PCP task dispatcher using ZMQ ROUTER/DEALER + torch.distributed broadcast.
 
     Tensor parallelism splits the model's weight matrices across ranks, so
     every rank must receive the same task metadata and the same input tensors.
     This dispatcher uses a ROUTER/DEALER pattern: the main rank (TP0/PCP0)
     serializes task metadata to all sibling ranks via ZMQ, then broadcasts
-    the input tensor payload using NCCL broadcast.
+    the input tensor payload using torch.distributed broadcast.
     """
 
     def __init__(
@@ -1484,7 +1485,7 @@ class Executor:
 
         - CP mode: every rank has its own independent PP pair and sends directly.
         - TP mode: only the main (TP0) rank sends, since hidden states are
-          already synchronized across TP ranks via NCCL broadcast.
+          already synchronized across TP ranks via torch.distributed broadcast.
         - The last PP stage does not send (there is no next stage).
         """
         if not get_pp_group().is_last_rank:

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -73,23 +73,33 @@ RESULT_TAG = 3
 
 
 class TasksDispatcher(ABC):
-    """Abstract communication interface for distributing tasks across parallel ranks.
-
-    Each parallelism strategy (TP, PP, DP, PCP) implements a dispatcher that
-    handles metadata dispatch (task IDs, sequence lengths, cache block assignments)
-    and tensor payload transfer (token IDs for the first PP stage, hidden states
-    for later stages).
+    """
+    Communication interface for a parallelism
 
     General workflow:
-    1. ``Executor.step()`` calls ``dispatch_metadata`` on each dispatcher.
-       Each dispatcher sends the task metadata to its sibling ranks.
-    2. For each model input tensor:
-       a. On the source rank (TP0/PCP0/PP stage 0), the Executor generates the
-          payload (token IDs for first PP stage, hidden states otherwise).
-       b. ``send_payload`` pushes the tensor to other ranks in the group.
-       c. On target ranks, ``recv_payload`` receives the tensor.
-    3. Every rank runs the model forward pass independently.
-    4. Results flow backward (PP last → PP first, DP workers → DP main rank).
+    1. `Executor` calls `dispatch_metadata` of this interface to let all corresponding
+        ranks know the task meta data.
+    2. for each model input:
+        1. on source rank, `Executor` generates model input, then calls `send_payload` of
+            this interface to send model input to other ranks.
+        2. on other ranks, `Executor` calls `recv_payload` of this interface to receive
+        model input from source rank.
+    3. `Executor` computes the model on every corresponding rank.
+
+    When combining multiple parallelism, generally we want a fused dispatcher dedicatedly
+    designed for this combined parallelism in order for higher performance. But if we don't
+    have such a fused dispatcher, we should chain multiple dispatchers. When chaining
+    dispatchers, we should take care of the order of dispatchers, and the dispatcher will
+    have an additional filter.
+
+    Example of calling `dispatch_metadata` on combined PP dispatcher with TP dispatcher:
+    1. `Executor` calls PP dispatcher, only on TP main ranks.
+    2. `Executor` calls TP disptchers, on all ranks.
+
+    In this example, during initialization, `Executor` should initialize the TP dispatcher
+    first, and initialize the PP dispatcher next only on filtered ranks. During execution,
+    `Executor` should call `dispatch_metadata` on the PP dispatcher first, and then call
+    `dispatch_metadata` on the TP dispatcher.
     """
 
     def __init__(
@@ -258,18 +268,10 @@ class TasksDispatcher(ABC):
 
 
 class PipeDispatcher(TasksDispatcher):
-    """Pipeline Parallelism (PP) dispatcher using point-to-point links.
+    """PP (Pipeline Parallelism) Dispatcher
 
-    Each PP stage sends hidden states to the next stage.  Metadata and tensor
-    payloads use different communication channels: metadata is serialized via
-    msgpack and forwarded through ZMQ PUSH/PULL sockets, while tensor payloads
-    are transferred with ``torch.distributed`` point-to-point operations.  The
-    ZMQ protocol automatically selects IPC (shared memory) when adjacent stages
-    reside on the same node, or TCP when they are on different nodes.
-
-    Only the first TP rank and first PCP rank within each PP stage participates
-    in metadata dispatch; tensor payloads use torch.distributed send/recv for
-    efficiency.
+    使用 ZMQ PUSH/PULL 模式（点对点，单向流水线传输）
+    协议选择：自动根据相邻 stages 是否同节点选择 ipc:// 或 tcp://
     """
 
     def __init__(
@@ -463,14 +465,7 @@ class PipeDispatcher(TasksDispatcher):
 
 
 class TensorDispatcher(TasksDispatcher):
-    """TP and PCP task dispatcher using ZMQ ROUTER/DEALER + torch.distributed broadcast.
-
-    Tensor parallelism splits the model's weight matrices across ranks, so
-    every rank must receive the same task metadata and the same input tensors.
-    This dispatcher uses a ROUTER/DEALER pattern: the main rank (TP0/PCP0)
-    serializes task metadata to all sibling ranks via ZMQ, then broadcasts
-    the input tensor payload using torch.distributed broadcast.
-    """
+    """TP (Tensor Parallelism) Dispatcher — also used for CP task dispatch."""
 
     def __init__(
         self,
@@ -561,13 +556,7 @@ class TensorDispatcher(TasksDispatcher):
 
 
 class ExpertDataDispatcher(TasksDispatcher):
-    """DP (Data Parallelism) dispatcher for distributing requests across DP ranks.
-
-    In data-parallel serving, each DP rank runs the full model independently
-    on a subset of the batch.  This dispatcher sends per-rank task metadata
-    from DP rank 0 to workers, and collects per-rank results (sampled tokens,
-    logprobs, PD first-token hints) back on rank 0 for merging.
-    """
+    """DP (Data Parallelism) Dispatcher"""
 
     def __init__(
         self,
@@ -978,14 +967,7 @@ class Executor:
         return self._kv_hook
 
     def _lb_trigger(self) -> None:
-        """Trigger MoE expert load-balancing at the configured interval.
-
-        Every ``moe_lb_trigger`` decode steps, the planner aggregates per-expert
-        load statistics from the current batch and generates an ordered list of
-        expert-migration actions.  The actual migration (P2P weight transfers)
-        is deferred to ``_lb_sync``, which commits only the layers whose
-        transfers have completed.
-        """
+        # 如果sysnc没有成功，不要开启下一步的trigger
         if not self._lb_enabled:
             return
         try:
@@ -1000,12 +982,6 @@ class Executor:
             pass
 
     def _lb_sync(self) -> None:
-        """Commit ready MoE expert-migration layers after load-balancing trigger.
-
-        Expert migration uses async P2P transfers; this method commits only the
-        layers whose transfers have finished.  Layers still in-flight are left
-        for the next sync.
-        """
         if not self._lb_enabled:
             return
         try:
@@ -1359,9 +1335,9 @@ class Executor:
     def prefill_step(self, tasks: PackedTasksBase) -> torch.Tensor:
         """Run a single prefill forward pass.
 
-        Prefill processes prompt tokens of newly scheduled requests in parallel,
-        producing KV cache entries and the hidden state or logits selected from
-        each request's last prompt token.
+        Prefill processes prompt tokens for scheduled requests, producing KV
+        cache entries and the selected hidden states or logits for output token
+        offsets requested by the scheduler.
 
         Steps:
         1. Prepare KV caches (allocate blocks, set sequence lengths).
@@ -1428,9 +1404,9 @@ class Executor:
     def decode_step(self, tasks: PackedTasksBase, is_empty_step: bool = False):
         """Run a single decode forward pass.
 
-        Decode processes one token per in-flight request, generating the next
-        token prediction.  For multi-token prediction (MTP) models, this
-        processes ``mtp_size`` tokens per request per step.
+        Decode consumes the current token for each in-flight request and produces
+        next-token predictions.  For multi-token prediction (MTP) models, the
+        model may draft multiple tokens per request in one decode step.
 
         Steps:
         1. Ensure KV cache is ready (for PD, this may wait for KV transfer from
@@ -1481,12 +1457,10 @@ class Executor:
             return self.dummy_mtp_output if self.mtp_size > 1 else self.dummy_output
 
     def _send_pp_payload(self, tensor, tasks):
-        """Send the model output to the next PP stage.
+        """Send payload to next PP stage if this rank should send.
 
-        - CP mode: every rank has its own independent PP pair and sends directly.
-        - TP mode: only the main (TP0) rank sends, since hidden states are
-          already synchronized across TP ranks via torch.distributed broadcast.
-        - The last PP stage does not send (there is no next stage).
+        CP mode: every rank has its own PP pair and sends independently.
+        TP mode: only the main rank sends (hiddens already synced via TP broadcast).
         """
         if not get_pp_group().is_last_rank:
             if self.cp_context.should_send_directly() or self.is_main_rank:
@@ -1581,15 +1555,16 @@ class Executor:
         """Run a DLLM (Diffusion LLM) decode step.
 
         Unlike standard autoregressive decode, DLLM operates on token *blocks*
-        of fixed length.  Each decode step iteratively refines a full block of
-        tokens via a masked-prediction loop until the block is fully decoded
-        (no mask tokens remain) or the maximum number of iterations is reached.
+        of fixed length.  Each decode step iteratively refines block payloads via
+        a masked-prediction loop until at least one block in the batch is fully
+        decoded (no mask tokens remain) or the maximum number of iterations is
+        reached.
 
         Steps:
         1. Prepare the block-length payload (mask tokens filled in for undecoded positions).
         2. Prepare DLLM-aware KV caches (``prepare_cache_decode_dllm``).
         3. Loop: forward → batch_decode → check block-finished condition.
-        4. Finalize caches and update task state with decoded block tokens.
+        4. Finalize caches and update task state for finished blocks.
         5. Queue finished blocks in ``_pending_dllm_block`` for later delivery
            via ``_process_dllm_block_results`` (which streams all tokens at once
            rather than one by one).
@@ -1844,22 +1819,12 @@ class Executor:
         TaskCollector.add_update_task_ids(tasks.output_task_ids)
 
     def postprocess_sync_part(self, current_tasks: PackedTasksBase):
-        """Synchronize sampled results to CPU and collect across DP workers.
+        """
+        schedule -> model -> sample -> ***sync*** -> send
 
-        This is the "sync" phase of the step pipeline:
+        Synchronize generated result to cpu.
 
-        ```
-        schedule → model → sample → ***sync*** → send (async, overlaps next step)
-        ```
-
-        Steps:
-        1. Collect results from PP (pipe results flow backward through the pipeline).
-        2. Move generated tokens to CPU (triggers CUDA synchronization).
-        3. Update token statistics (generated count, MTP accept rate).
-        4. Collect per-DP-rank results to DP rank 0 and merge.
-        5. Update response streams with new tokens.
-        6. When schedule-overlap is enabled, predict which tasks will stop after
-           this step so the scheduler can pre-warm their replacements.
+        After synchronizing, collect result across dp workers to dp main rank and update tasks.
         """
         tasks = self._collect_task_and_pp_results(current_tasks)
         if self.model_type == ModelType.LLADA2:

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -73,33 +73,30 @@ RESULT_TAG = 3
 
 
 class TasksDispatcher(ABC):
-    """
-    Communication interface for a parallelism
+    """Abstract communication interface for distributing tasks across parallel ranks.
+
+    Each parallelism strategy (TP, PP, DP, PCP) implements a dispatcher that
+    handles metadata dispatch (task IDs, sequence lengths, cache block assignments)
+    and tensor payload transfer (token IDs for the first PP stage, hidden states
+    for later stages).
 
     General workflow:
-    1. `Executor` calls `dispatch_metadata` of this interface to let all corresponding
-        ranks know the task meta data.
-    2. for each model input:
-        1. on source rank, `Executor` generates model input, then calls `send_payload` of
-            this interface to send model input to other ranks.
-        2. on other ranks, `Executor` calls `recv_payload` of this interface to receive
-        model input from source rank.
-    3. `Executor` computes the model on every corresponding rank.
+    1. ``Executor.step()`` calls ``dispatch_metadata`` on each dispatcher in
+       depth-first order (pipe → PCP → TP → DP).  Each dispatcher sends the
+       task metadata to its sibling ranks.
+    2. For each model input tensor:
+       a. On the source rank (TP0/PCP0/PP stage 0), the Executor generates the
+          payload (token IDs for first PP stage, hidden states otherwise).
+       b. ``send_payload`` pushes the tensor to other ranks in the group.
+       c. On target ranks, ``recv_payload`` receives the tensor.
+    3. Every rank runs the model forward pass independently.
+    4. Results flow backward (PP last → PP first, DP workers → DP main rank).
 
-    When combining multiple parallelism, generally we want a fused dispatcher dedicatedly
-    designed for this combined parallelism in order for higher performance. But if we don't
-    have such a fused dispatcher, we should chain multiple dispatchers. When chaining
-    dispatchers, we should take care of the order of dispatchers, and the dispatcher will
-    have an additional filter.
-
-    Example of calling `dispatch_metadata` on combined PP dispatcher with TP dispatcher:
-    1. `Executor` calls PP dispatcher, only on TP main ranks.
-    2. `Executor` calls TP disptchers, on all ranks.
-
-    In this example, during initialization, `Executor` should initialize the TP dispatcher
-    first, and initialize the PP dispatcher next only on filtered ranks. During execution,
-    `Executor` should call `dispatch_metadata` on the PP dispatcher first, and then call
-    `dispatch_metadata` on the TP dispatcher.
+    When combining multiple parallelism strategies, dispatchers are chained:
+    the executor prepends them in order so that outer dispatchers (PP) wrap
+    inner ones (TP, DP).  Only ranks that are "main" for a given parallelism
+    level participate in its dispatcher communication.  See ``Executor.step()``
+    for the dispatch ordering.
     """
 
     def __init__(
@@ -268,10 +265,16 @@ class TasksDispatcher(ABC):
 
 
 class PipeDispatcher(TasksDispatcher):
-    """PP (Pipeline Parallelism) Dispatcher
+    """Pipeline Parallelism (PP) dispatcher using ZMQ PUSH/PULL point-to-point links.
 
-    使用 ZMQ PUSH/PULL 模式（点对点，单向流水线传输）
-    协议选择：自动根据相邻 stages 是否同节点选择 ipc:// 或 tcp://
+    Each PP stage sends hidden states to the next stage via ZMQ.  The protocol
+    automatically selects IPC (shared memory) when adjacent stages reside on the
+    same node, or TCP when they are on different nodes.  Metadata (task IDs,
+    sequence lengths, slot indices) is serialized via msgpack and forwarded
+    through the pipeline alongside the tensor payloads.
+
+    Only the first TP rank and first PCP rank within each PP stage participates
+    in metadata dispatch; tensor payloads use NCCL send/recv for efficiency.
     """
 
     def __init__(
@@ -465,7 +468,14 @@ class PipeDispatcher(TasksDispatcher):
 
 
 class TensorDispatcher(TasksDispatcher):
-    """TP (Tensor Parallelism) Dispatcher — also used for CP task dispatch."""
+    """TP and PCP task dispatcher using ZMQ ROUTER/DEALER + NCCL broadcast.
+
+    Tensor parallelism splits the model's weight matrices across ranks, so
+    every rank must receive the same task metadata and the same input tensors.
+    This dispatcher uses a ROUTER/DEALER pattern: the main rank (TP0/PCP0)
+    serializes task metadata to all sibling ranks via ZMQ, then broadcasts
+    the input tensor payload using NCCL broadcast.
+    """
 
     def __init__(
         self,
@@ -556,7 +566,13 @@ class TensorDispatcher(TasksDispatcher):
 
 
 class ExpertDataDispatcher(TasksDispatcher):
-    """DP (Data Parallelism) Dispatcher"""
+    """DP (Data Parallelism) dispatcher for distributing requests across DP ranks.
+
+    In data-parallel serving, each DP rank runs the full model independently
+    on a subset of the batch.  This dispatcher sends per-rank task metadata
+    from DP rank 0 to workers, and collects per-rank results (sampled tokens,
+    logprobs, PD first-token hints) back on rank 0 for merging.
+    """
 
     def __init__(
         self,
@@ -967,7 +983,14 @@ class Executor:
         return self._kv_hook
 
     def _lb_trigger(self) -> None:
-        # 如果sysnc没有成功，不要开启下一步的trigger
+        """Trigger MoE expert load-balancing at the configured interval.
+
+        Every ``moe_lb_trigger`` decode steps, the planner aggregates per-expert
+        load statistics from the current batch and generates an ordered list of
+        expert-migration actions.  The actual migration (P2P weight transfers)
+        is deferred to ``_lb_sync``, which commits only the layers whose
+        transfers have completed.
+        """
         if not self._lb_enabled:
             return
         try:
@@ -982,6 +1005,12 @@ class Executor:
             pass
 
     def _lb_sync(self) -> None:
+        """Commit ready MoE expert-migration layers after load-balancing trigger.
+
+        Expert migration uses async P2P transfers; this method commits only the
+        layers whose transfers have finished.  Layers still in-flight are left
+        for the next sync.
+        """
         if not self._lb_enabled:
             return
         try:
@@ -1095,7 +1124,27 @@ class Executor:
     def step(
         self, tasks: Optional[PackedTasksBase]
     ) -> SerializedPackedTasksPayloadType:
-        # 1. propagate tasks and handle special payload type
+        """Execute one inference step — dispatch tasks, run the model, and collect results.
+
+        This is the heart of the executor.  A step proceeds through these phases:
+
+        1. **Metadata dispatch** — each dispatcher (PP → PCP → TP → DP) serializes
+           task metadata and sends it to its sibling ranks via ZMQ.  After
+           dispatch, every rank that participates in the step has a local copy
+           of the task descriptors.
+
+        2. **Special payload handling** — ``TerminateBackend`` sets the backend
+           state to Terminated; ``EndTask`` cleans up finished tasks (KV cache
+           eviction, sampler state removal, TaskPool cleanup).
+
+        3. **Process queue** — runs a sequence of callbacks configured at init:
+           - Normal mode: model_run → process_last_batch_results → postprocess_sync
+           - Schedule-overlap mode: postprocess_sync → model_run → process_last_batch_results
+           The overlap mode pipelines CPU postprocessing of step N with GPU work
+           for step N+1.
+
+        Returns the serialized payload type (Empty, Normal, TerminateBackend, EndTask).
+        """
         payload_type = tasks.payload_type if tasks is not None else None
 
         for dispatcher in self.task_dispatchers:
@@ -1176,7 +1225,21 @@ class Executor:
             return torch.arange(tasks.num_tasks, dtype=torch.int32, device=self.device)
 
     def model_run(self, tasks: PackedTasksBase):
-        if tasks.payload_type == SerializedPackedTasksPayloadType.Empty:
+        """Run the model forward pass for one step — prefill or decode.
+
+        This method:
+        1. Prepares the MoE implementation for the step (sets task type and
+           number of tokens so MoE layers can configure their dispatchers).
+        2. Prepares KV caches for the step via ``prepare_cache_prefill`` or
+           ``prepare_cache_decode``.
+        3. Builds the input payload (token IDs for first PP stage, hidden
+           states for later stages).
+        4. Calls ``Backend.model.prefill()`` or ``Backend.model.decode()``.
+        5. Sends the output to the next PP stage via ``_send_pp_payload``.
+        6. On the sample rank (TP0 + PCP0 + last PP stage), runs the sampler
+           to produce next-token predictions.
+        7. Notifies the KV transfer hook after prefill for PD disaggregation.
+        """
             if not self.is_pp_first_stage:
                 self._collect_task_and_pp_results(tasks)
             return
@@ -1299,7 +1362,21 @@ class Executor:
         return hiddens
 
     def prefill_step(self, tasks: PackedTasksBase) -> torch.Tensor:
-        is_empty_step = tasks.num_tasks == 0
+        """Run a single prefill forward pass.
+
+        Prefill processes the prompt tokens of newly scheduled requests in
+        parallel.  Each request's full prompt is fed through the model at once,
+        producing the KV cache entries for all prompt tokens and the hidden
+        state of the last token (used for first-token sampling).
+
+        Steps:
+        1. Prepare KV caches (allocate blocks, set sequence lengths).
+        2. Gather token IDs from task descriptors into a flat tensor.
+        3. Receive hidden states from the previous PP stage (if not stage 0).
+        4. Call ``Backend.model.prefill()``.
+        5. Send output hidden states to the next PP stage.
+        6. Collect prompt token metrics for Prometheus.
+        """
         if not is_empty_step:
             for cache in Backend.cache_dict.values():
                 cache.prepare_cache_prefill(tasks)
@@ -1354,7 +1431,21 @@ class Executor:
             return self.dummy_output
 
     def decode_step(self, tasks: PackedTasksBase, is_empty_step: bool = False):
-        if tasks.num_tasks == 0:
+        """Run a single decode forward pass.
+
+        Decode processes one token per in-flight request, generating the next
+        token prediction.  For multi-token prediction (MTP) models, this
+        processes ``mtp_size`` tokens per request per step.
+
+        Steps:
+        1. Ensure KV cache is ready (for PD, this may wait for KV transfer from
+           the prefill side to complete).
+        2. Prepare KV caches — update block tables and sequence lengths.
+        3. Build the payload: token IDs (first PP stage) or hidden states
+           (later PP stages) received from the previous PP stage.
+        4. Call ``Backend.model.decode()``.
+        5. Send the output to the next PP stage.
+        """
             is_empty_step = True
         if not is_empty_step:
             # Ensure KV cache is present for PD decode-only before updating CacheManager state.
@@ -1394,10 +1485,12 @@ class Executor:
             return self.dummy_mtp_output if self.mtp_size > 1 else self.dummy_output
 
     def _send_pp_payload(self, tensor, tasks):
-        """Send payload to next PP stage if this rank should send.
+        """Send the model output to the next PP stage.
 
-        CP mode: every rank has its own PP pair and sends independently.
-        TP mode: only the main rank sends (hiddens already synced via TP broadcast).
+        - CP mode: every rank has its own independent PP pair and sends directly.
+        - TP mode: only the main (TP0) rank sends, since hidden states are
+          already synchronized across TP ranks via NCCL broadcast.
+        - The last PP stage does not send (there is no next stage).
         """
         if not get_pp_group().is_last_rank:
             if self.cp_context.should_send_directly() or self.is_main_rank:
@@ -1489,7 +1582,22 @@ class Executor:
         return logits
 
     def decode_dllm_step(self, tasks: PackedTasksBase) -> torch.Tensor:
-        """DLLM decode: payload is the full block per task, forward + batch_decode + update state."""
+        """Run a DLLM (Diffusion LLM) decode step.
+
+        Unlike standard autoregressive decode, DLLM operates on token *blocks*
+        of fixed length.  Each decode step iteratively refines a full block of
+        tokens via a masked-prediction loop until the block is fully decoded
+        (no mask tokens remain) or the maximum number of iterations is reached.
+
+        Steps:
+        1. Prepare the block-length payload (mask tokens filled in for undecoded positions).
+        2. Prepare DLLM-aware KV caches (``prepare_cache_decode_dllm``).
+        3. Loop: forward → batch_decode → check block-finished condition.
+        4. Finalize caches and update task state with decoded block tokens.
+        5. Queue finished blocks in ``_pending_dllm_block`` for later delivery
+           via ``_process_dllm_block_results`` (which streams all tokens at once
+           rather than one by one).
+        """
         if tasks.num_tasks == 0:
             return self.dummy_output
         if self.tp_size <= 1 and not isinstance(tasks, PackedTasks):
@@ -1740,12 +1848,22 @@ class Executor:
         TaskCollector.add_update_task_ids(tasks.output_task_ids)
 
     def postprocess_sync_part(self, current_tasks: PackedTasksBase):
-        """
-        schedule -> model -> sample -> ***sync*** -> send
+        """Synchronize sampled results to CPU and collect across DP workers.
 
-        Synchronize generated result to cpu.
+        This is the "sync" phase of the step pipeline:
 
-        After synchronizing, collect result across dp workers to dp main rank and update tasks.
+        ```
+        schedule → model → sample → ***sync*** → send (async, overlaps next step)
+        ```
+
+        Steps:
+        1. Collect results from PP (pipe results flow backward through the pipeline).
+        2. Move generated tokens to CPU (triggers CUDA synchronization).
+        3. Update token statistics (generated count, MTP accept rate).
+        4. Collect per-DP-rank results to DP rank 0 and merge.
+        5. Update response streams with new tokens.
+        6. When schedule-overlap is enabled, predict which tasks will stop after
+           this step so the scheduler can pre-warm their replacements.
         """
         tasks = self._collect_task_and_pp_results(current_tasks)
         if self.model_type == ModelType.LLADA2:

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -1123,9 +1123,9 @@ class Executor:
 
         This is the heart of the executor.  A step proceeds through these phases:
 
-        1. **Metadata dispatch** — each dispatcher serializes task metadata and
-           sends it to its sibling ranks via ZMQ.  After dispatch, every rank
-           that participates in the step has a local copy of the task descriptors.
+        1. **Metadata dispatch** — each dispatcher propagates task metadata to
+           its sibling ranks.  After dispatch, every rank that participates in
+           the step has a local copy of the task descriptors.
 
         2. **Special payload handling** — ``TerminateBackend`` sets the backend
            state to Terminated; ``EndTask`` cleans up finished tasks (KV cache
@@ -1229,7 +1229,7 @@ class Executor:
         3. Builds the input payload (token IDs for first PP stage, hidden
            states for later stages).
         4. Calls ``Backend.model.prefill()`` or ``Backend.model.decode()``.
-        5. Sends the output to the next PP stage via ``_send_pp_payload``.
+        5. Sends the output to the next PP stage when applicable.
         6. On the sample rank (TP0 + PCP0 + last PP stage), runs the sampler
            to produce next-token predictions.
         7. Notifies the KV transfer hook after prefill for PD disaggregation.
@@ -1360,15 +1360,15 @@ class Executor:
         """Run a single prefill forward pass.
 
         Prefill processes prompt tokens of newly scheduled requests in parallel,
-        producing KV cache entries and the hidden state of the last token used
-        for first-token sampling.
+        producing KV cache entries and the hidden state or logits selected from
+        each request's last prompt token.
 
         Steps:
         1. Prepare KV caches (allocate blocks, set sequence lengths).
         2. Gather token IDs from task descriptors into a flat tensor.
         3. Receive hidden states from the previous PP stage (if not stage 0).
         4. Call ``Backend.model.prefill()``.
-        5. Send output hidden states to the next PP stage.
+        5. Send output hidden states to the next PP stage when applicable.
         6. Collect prompt token metrics for Prometheus.
         """
         is_empty_step = tasks.num_tasks == 0

--- a/chitu/kv_cache/cache_manager.py
+++ b/chitu/kv_cache/cache_manager.py
@@ -44,10 +44,6 @@ class PagedKVCacheManager(KVCacheManagerBase):
     - Free block pool (reclaimed when tasks finish or blocks are evicted).
     - Optional prefix-cache metadata: tracks block hashes and reference counts
       to enable block sharing across requests with shared prefixes.
-
-    The manager is per-DP-rank: rank 0's manager makes scheduling decisions,
-    and worker ranks replicate the metadata via ``prepare_metadata_before_*``
-    calls after ZMQ dispatch.
     """
 
     def __init__(

--- a/chitu/kv_cache/cache_manager.py
+++ b/chitu/kv_cache/cache_manager.py
@@ -29,8 +29,8 @@ class KVCacheManagerBase:
     While ``KVCacheBase`` owns the GPU tensor storage, ``KVCacheManagerBase``
     owns the allocation metadata: which blocks are assigned to which task,
     which blocks are free, and (with prefix caching) which blocks are shared.
-    The manager is consulted by the scheduler for admission control and by the
-    executor's ``prepare_cache_*`` methods to allocate/reclaim blocks.
+    The scheduler uses the manager for admission control and to populate the
+    block metadata that the executor later consumes in ``prepare_cache_*``.
     """
 
     pass

--- a/chitu/kv_cache/cache_manager.py
+++ b/chitu/kv_cache/cache_manager.py
@@ -24,10 +24,31 @@ logger = getLogger(__name__)
 
 
 class KVCacheManagerBase:
+    """Base class for KV cache managers — the scheduler-side counterpart of KVCacheBase.
+
+    While ``KVCacheBase`` owns the GPU tensor storage, ``KVCacheManagerBase``
+    owns the allocation metadata: which blocks are assigned to which task,
+    which blocks are free, and (with prefix caching) which blocks are shared.
+    The manager is consulted by the scheduler for admission control and by the
+    executor's ``prepare_cache_*`` methods to allocate/reclaim blocks.
+    """
+
     pass
 
 
 class PagedKVCacheManager(KVCacheManagerBase):
+    """Block allocator for paged KV caches with optional prefix caching.
+
+    Maintains:
+    - ``task_to_cache_ids``: maps each task to its allocated physical block IDs.
+    - Free block pool (reclaimed when tasks finish or blocks are evicted).
+    - Optional prefix-cache metadata: tracks block hashes and reference counts
+      to enable block sharing across requests with shared prefixes.
+
+    The manager is per-DP-rank: rank 0's manager makes scheduling decisions,
+    and worker ranks replicate the metadata via ``prepare_metadata_before_*``
+    calls after ZMQ dispatch.
+    """
 
     def __init__(
         self,

--- a/chitu/kv_cache/kv_cache.py
+++ b/chitu/kv_cache/kv_cache.py
@@ -129,11 +129,17 @@ class GlobalLocalMap:
 
 
 class KVCacheAccessor:
-    """
-    Base class for KV cache accessors
+    """Lightweight descriptor passed to attention kernels to locate cached KV states.
 
-    A KV cache accessor locates specific tokens of a specific layer in a KV cache. Data
-    can be read from the accessor, and updates to the accessor apply to the KV cache.
+    An accessor is a view into a specific layer's KV cache.  It carries the
+    tensors and metadata that the attention backend needs to read (and
+    optionally update) cached key/value data without coupling to the underlying
+    cache storage layout (paged vs. dense).
+
+    Subclasses add layout-specific fields: ``PagedKVCacheAccessor`` carries
+    block tables for page-to-physical-address translation, while
+    ``DenseKVCacheAccessor`` carries contiguous tensors indexed directly by
+    request and position.
     """
 
     pass
@@ -477,6 +483,23 @@ class KVCacheBase:
 
 
 class PagedKVCache(KVCacheBase):
+    """Paged KV cache with virtual-to-physical block mapping.
+
+    Inspired by OS virtual memory, PagedKVCache divides the KV cache into
+    fixed-size blocks (pages) and maps each request's logical positions to
+    physical blocks via a block table.  This eliminates fragmentation: blocks
+    can be allocated on demand and reclaimed independently per request.
+
+    Key design points:
+    - ``block_table``: (num_hot_req, max_blocks_per_req) — maps each request's
+      logical block offsets to physical block indices.
+    - ``block_size``: Must be a multiple of 256 for FlashAttention compatibility.
+    - Prefix caching: when enabled, blocks with identical content are shared
+      across requests (managed by the cache manager, not the cache itself).
+    - ``allocatable_max_num_blocks``: With prefix caching, this is virtually
+      unbounded; without it, it equals ``page_table_max_num_blocks``.
+    """
+
     def __init__(
         self,
         layer_id_map: GlobalLocalMap,
@@ -1250,6 +1273,15 @@ class MMPagedKVCache(PagedKVCache):
 
 
 class DenseKVCache(KVCacheBase):
+    """Contiguous (non-paged) KV cache — one fixed-size buffer per request.
+
+    In contrast to ``PagedKVCache``, DenseKVCache pre-allocates a contiguous
+    region of ``[max_seq_len, shape_per_token...]`` for each hot request.
+    This is simpler and avoids block-table indirection, but is memory-inefficient
+    for long sequences with variable lengths.  It is primarily used for the
+    "skew" cache type (legacy) and for specialized DeepSeek-V4 caches.
+    """
+
     def __init__(
         self,
         layer_id_map: GlobalLocalMap,

--- a/chitu/kv_cache/kv_cache.py
+++ b/chitu/kv_cache/kv_cache.py
@@ -485,18 +485,16 @@ class KVCacheBase:
 class PagedKVCache(KVCacheBase):
     """Paged KV cache with virtual-to-physical block mapping.
 
-    Inspired by OS virtual memory, PagedKVCache divides the KV cache into
-    fixed-size blocks (pages) and maps each request's logical positions to
-    physical blocks via a block table.  This eliminates fragmentation: blocks
-    can be allocated on demand and reclaimed independently per request.
+    PagedKVCache divides the KV cache into fixed-size blocks (pages) and maps
+    each request's logical positions to physical blocks via a block table.
 
     Key design points:
-    - ``block_table``: (num_hot_req, max_blocks_per_req) — maps each request's
-      logical block offsets to physical block indices.
-    - Prefix caching: when enabled, blocks with identical content are shared
-      across requests (managed by the cache manager, not the cache itself).
-    - ``allocatable_max_num_blocks``: With prefix caching, this is virtually
-      unbounded; without it, it equals ``page_table_max_num_blocks``.
+    - ``block_table``: maps each request's logical block offsets to physical
+      block indices.
+    - Prefix-cache sharing, when enabled for a cache type, is managed by the
+      cache manager rather than the cache itself.
+    - ``allocatable_max_num_blocks`` records the effective upper bound used by
+      warmup-time reallocation.
     """
 
     def __init__(

--- a/chitu/kv_cache/kv_cache.py
+++ b/chitu/kv_cache/kv_cache.py
@@ -1275,11 +1275,8 @@ class MMPagedKVCache(PagedKVCache):
 class DenseKVCache(KVCacheBase):
     """Contiguous (non-paged) KV cache — one fixed-size buffer per request.
 
-    In contrast to ``PagedKVCache``, DenseKVCache pre-allocates a contiguous
-    region of ``[max_seq_len, shape_per_token...]`` for each hot request.
-    This is simpler and avoids block-table indirection, but is memory-inefficient
-    for long sequences with variable lengths.  It is primarily used for the
-    "skew" cache type (legacy) and for specialized DeepSeek-V4 caches.
+    DenseKVCache is designed for dense (a.k.a. skew) KV cache. Additionally,
+    it is used for some auxiliary fixed-length KV caches in some models.
     """
 
     def __init__(

--- a/chitu/kv_cache/kv_cache.py
+++ b/chitu/kv_cache/kv_cache.py
@@ -493,7 +493,6 @@ class PagedKVCache(KVCacheBase):
     Key design points:
     - ``block_table``: (num_hot_req, max_blocks_per_req) — maps each request's
       logical block offsets to physical block indices.
-    - ``block_size``: Must be a multiple of 256 for FlashAttention compatibility.
     - Prefix caching: when enabled, blocks with identical content are shared
       across requests (managed by the cache manager, not the cache itself).
     - ``allocatable_max_num_blocks``: With prefix caching, this is virtually

--- a/chitu/models/model.py
+++ b/chitu/models/model.py
@@ -283,22 +283,8 @@ class TransformerBlock(nn.Module):
 
 
 class Transformer(nn.Module):
-    """Base class for all language models in Chitu.
-
-    The Transformer owns the full model lifecycle:
-    - Embedding table and final lm_head projection.
-    - A stack of ``layers`` (``TransformerBlock`` instances), each with
-      attention + MLP (optionally MoE).
-    - Parallelism setup: partitions layers across PP stages, experts across
-      EP ranks, and heads across TP ranks.
-    - CUDA graph capture for decode (the latency-critical path).
-
-    Subclasses (``model_deepseek_v3.py``, ``model_hf_llama.py``, etc.)
-    implement the specific architecture by overriding:
-    - Layer construction (attention type, MLP type, norm positions).
-    - ``prefill`` and ``decode`` forward passes.
-    - ``load_state_dict_parallel`` and ``_get_layer_i_prefix_mapping`` for
-      checkpoint loading.
+    """
+    Base class for model architectures in Chitu.
     """
 
     def __init__(

--- a/chitu/models/model.py
+++ b/chitu/models/model.py
@@ -283,6 +283,25 @@ class TransformerBlock(nn.Module):
 
 
 class Transformer(nn.Module):
+    """Base class for all language models in Chitu.
+
+    The Transformer owns the full model lifecycle:
+    - Embedding table and final lm_head projection.
+    - A stack of ``layers`` (``TransformerBlock`` instances), each with
+      attention + MLP (optionally MoE).
+    - KV caches (paged or dense) shared across layers.
+    - Parallelism setup: partitions layers across PP stages, experts across
+      EP ranks, and heads across TP ranks.
+    - CUDA graph capture for decode (the latency-critical path).
+
+    Subclasses (``model_deepseek_v3.py``, ``model_hf_llama.py``, etc.)
+    implement the specific architecture by overriding:
+    - Layer construction (attention type, MLP type, norm positions).
+    - ``prefill`` and ``decode`` forward passes.
+    - ``load_state_dict_parallel`` and ``_get_layer_i_prefix_mapping`` for
+      checkpoint loading.
+    """
+
     def __init__(
         self,
         params,
@@ -1691,6 +1710,27 @@ class Transformer(nn.Module):
         output_token_offsets: torch.Tensor,
         **args,
     ) -> torch.Tensor:
+        """Run the prefill forward pass.
+
+        Prefill processes all prompt tokens in parallel, caching the KV states
+        for every position and returning the hidden states of the last token
+        per request (specified by ``output_token_offsets``).
+
+        In PP mode, ``tokens`` is None on non-first stages (hidden states are
+        received from the preceding stage).  The first stage embeds tokens and
+        sends hidden states downstream; intermediate stages process hidden
+        states only; the last stage projects to logits.
+
+        Args:
+            tokens: Flat tensor of token IDs for the first PP stage; None
+                   for later stages (which receive hidden states).
+            hiddens: Hidden states from the previous PP stage (None for stage 0).
+            output_token_offsets: Per-request positions of the last prompt token
+                                  (used to extract the logits for sampling).
+        Returns:
+            Logits for the last prompt token of each request (on the last PP
+            stage), or hidden states to forward to the next PP stage.
+        """
         if hiddens is not None and len(hiddens) == 0:
             return self.empty_prefill()
         if tokens is not None and len(tokens) == 0:

--- a/chitu/models/model.py
+++ b/chitu/models/model.py
@@ -289,7 +289,6 @@ class Transformer(nn.Module):
     - Embedding table and final lm_head projection.
     - A stack of ``layers`` (``TransformerBlock`` instances), each with
       attention + MLP (optionally MoE).
-    - KV caches (paged or dense) shared across layers.
     - Parallelism setup: partitions layers across PP stages, experts across
       EP ranks, and heads across TP ranks.
     - CUDA graph capture for decode (the latency-critical path).
@@ -1712,9 +1711,8 @@ class Transformer(nn.Module):
     ) -> torch.Tensor:
         """Run the prefill forward pass.
 
-        Prefill processes all prompt tokens in parallel, caching the KV states
-        for every position and returning the hidden states of the last token
-        per request (specified by ``output_token_offsets``).
+        Prefill caches KV states for prompt tokens and returns the hidden states
+        of the last token per request (specified by ``output_token_offsets``).
 
         In PP mode, ``tokens`` is None on non-first stages (hidden states are
         received from the preceding stage).  The first stage embeds tokens and

--- a/chitu/models/model.py
+++ b/chitu/models/model.py
@@ -1697,8 +1697,9 @@ class Transformer(nn.Module):
     ) -> torch.Tensor:
         """Run the prefill forward pass.
 
-        Prefill caches KV states for prompt tokens and returns the hidden states
-        of the last token per request (specified by ``output_token_offsets``).
+        Prefill caches KV states for prompt tokens and returns the selected
+        hidden states or logits for the last prompt token of each request
+        (specified by ``output_token_offsets``).
 
         In PP mode, ``tokens`` is None on non-first stages (hidden states are
         received from the preceding stage).  The first stage embeds tokens and
@@ -1710,7 +1711,7 @@ class Transformer(nn.Module):
                    for later stages (which receive hidden states).
             hiddens: Hidden states from the previous PP stage (None for stage 0).
             output_token_offsets: Per-request positions of the last prompt token
-                                  (used to extract the logits for sampling).
+                                  (used to select outputs for sampling).
         Returns:
             Logits for the last prompt token of each request (on the last PP
             stage), or hidden states to forward to the next PP stage.

--- a/chitu/moe/impl.py
+++ b/chitu/moe/impl.py
@@ -47,7 +47,13 @@ MOE_IMPL_INSTANCE: Optional["MoEImplBase"] = None
 
 
 def init_moe_impl(args) -> None:
-    """Initialize MoEImpl instance."""
+    """Create the global MoE implementation singleton.
+
+    Picks between ``MoEImplEP`` (expert-parallel, requires ``ep_size > 1``) and
+    ``MoEImplNoEP`` (all experts replicated on every rank).  The choice is
+    driven by ``args.infer.ep_size``.  The instance is stored in the module-level
+    ``MOE_IMPL_INSTANCE`` singleton and retrieved by ``get_moe_impl()``.
+    """
     global MOE_IMPL_INSTANCE
     assert MOE_IMPL_INSTANCE is None, "moe impl already initialized"
 
@@ -131,6 +137,23 @@ def get_moe_impl() -> Optional["MoEImplBase"]:
 
 
 class MoEImplBase:
+    """Base class for Mixture-of-Experts dispatch implementations.
+
+    The MoE implementation coordinates expert dispatch and combine across
+    parallelism dimensions.  It is called by every transformer layer's
+    ``ParallelMoeBlock.forward()``:
+
+    1. **Gate** — compute routing weights and expert indices (in the model).
+    2. **Dispatch** — send each token's hidden state to the assigned expert.
+    3. **Expert compute** — run the expert FFN on received tokens.
+    4. **Combine** — return output tokens to their original positions.
+
+    Subclasses implement two strategies:
+    - ``MoEImplNoEP``: all experts are on every rank; dispatch is local.
+    - ``MoEImplEP``: experts are partitioned across EP ranks; dispatch uses
+      all-to-all collectives (via DeepEP, NCCL, or NPU all-to-all).
+    """
+
     def __init__(
         self,
         n_routed_experts: int,

--- a/chitu/moe/impl.py
+++ b/chitu/moe/impl.py
@@ -137,21 +137,8 @@ def get_moe_impl() -> Optional["MoEImplBase"]:
 
 
 class MoEImplBase:
-    """Base class for Mixture-of-Experts dispatch implementations.
-
-    The MoE implementation coordinates expert dispatch and combine across
-    parallelism dimensions.  It is called by every transformer layer's
-    ``ParallelMoeBlock.forward()``:
-
-    1. **Gate** — compute routing weights and expert indices (in the model).
-    2. **Dispatch** — send each token's hidden state to the assigned expert.
-    3. **Expert compute** — run the expert FFN on received tokens.
-    4. **Combine** — return output tokens to their original positions.
-
-    Subclasses implement two strategies:
-    - ``MoEImplNoEP``: all experts are on every rank; dispatch is local.
-    - ``MoEImplEP``: experts are partitioned across EP ranks; dispatch uses
-      all-to-all collectives (via DeepEP, NCCL, or NPU all-to-all).
+    """
+    Base class for Mixture-of-Experts dispatching implementations.
     """
 
     def __init__(

--- a/chitu/scheduler.py
+++ b/chitu/scheduler.py
@@ -28,12 +28,34 @@ logger = getLogger(__name__)
 
 
 class KVCacheCapacityStatus(Enum):
+    """Result of a KV cache capacity check for a candidate task.
+
+    OK:
+        The task can be scheduled — enough free blocks are available.
+    CONGESTED:
+        The task needs more blocks than currently free, but the total number
+        of blocks it would need (after running to completion) is within the
+        cache's physical capacity.  The scheduler should skip this task for
+        now and retry later when in-flight prefill tasks have released blocks.
+    EXCEEDS_CAPACITY:
+        The task's sequence length requires more blocks than the cache can
+        physically hold, even if all blocks were free.  The task must be
+        terminated (evicted).
+    """
     OK = auto()
     CONGESTED = auto()
     EXCEEDS_CAPACITY = auto()
 
 
 class SchedulerGroupList:
+    """Ring-buffer of schedule groups for pipeline parallelism.
+
+    In PP mode, ``pp_size`` schedule groups rotate each step so that tasks
+    entering the pipeline in step N complete their prefill and enter decode
+    synchronously.  Each group tracks the task IDs that were scheduled in its
+    slot; when the slot wraps around, its tasks are released (``unwait()``).
+    """
+
     def __init__(self, num_sgroup: int, type: str = "paged"):
         self.num_sgroup = num_sgroup
         self.type = type
@@ -317,12 +339,18 @@ class Scheduler:
     def _inflight_prefill_reserved_blocks(
         self, cache_manager, exclude_task_id: str
     ) -> int:
-        """已开始prefill但未完成（仍持有块、task_type仍为Prefill）的任务，跑到完整
-        prompt长度还需要的块数之和。准入新prefill时必须为它们预留这些块，否则会出现
-        多个在途prefill互相占用、谁都无法跑完、谁都到不了decode释放块的死锁。
+        """Count blocks that in-flight prefill tasks still need to reach their full prompt length.
+
+        When admitting a new prefill task, the scheduler must reserve enough
+        blocks for every already-running prefill to finish.  Without this
+        reservation, multiple partial prefill tasks could each hold blocks while
+        waiting for more, creating a deadlock where none can reach decode (the
+        only phase that releases blocks).
+
         Args:
-            cache_manager: 当前正在统计预留块的cache_manager
-            exclude_task_id: 排除的task_id（通常是当前正在检查容量的任务自身）
+            cache_manager: The cache manager to count against.
+            exclude_task_id: Exclude this task from the count (typically the
+                candidate task being evaluated for admission).
         """
         reserved = 0
         for tid, cache_ids in cache_manager.task_to_cache_ids.items():

--- a/chitu/scheduler.py
+++ b/chitu/scheduler.py
@@ -50,10 +50,9 @@ class KVCacheCapacityStatus(Enum):
 class SchedulerGroupList:
     """Ring-buffer of schedule groups for pipeline parallelism.
 
-    In PP mode, ``pp_size`` schedule groups rotate each step so that tasks
-    entering the pipeline in step N complete their prefill and enter decode
-    synchronously.  Each group tracks the task IDs that were scheduled in its
-    slot; when the slot wraps around, its tasks are released (``unwait()``).
+    In PP mode, schedule groups rotate each step.  Each group records the task
+    IDs scheduled in its slot so they can be marked waiting and later released
+    with ``unwait()`` after the corresponding pipeline delay.
     """
 
     def __init__(self, num_sgroup: int, type: str = "paged"):
@@ -344,8 +343,7 @@ class Scheduler:
         When admitting a new prefill task, the scheduler must reserve enough
         blocks for every already-running prefill to finish.  Without this
         reservation, multiple partial prefill tasks could each hold blocks while
-        waiting for more, creating a deadlock where none can reach decode (the
-        only phase that releases blocks).
+        waiting for more, creating a deadlock where none can reach decode.
 
         Args:
             cache_manager: The cache manager to count against.

--- a/chitu/scheduler.py
+++ b/chitu/scheduler.py
@@ -34,14 +34,14 @@ class KVCacheCapacityStatus(Enum):
         The task can be scheduled — enough free blocks are available.
     CONGESTED:
         The task needs more blocks than currently free, but the total number
-        of blocks it would need (after running to completion) is within the
-        cache's physical capacity.  The scheduler should skip this task for
-        now and retry later when in-flight prefill tasks have released blocks.
+        of blocks it would need is within the cache's physical capacity.  The
+        scheduler should skip this task for now and retry later.
     EXCEEDS_CAPACITY:
         The task's sequence length requires more blocks than the cache can
         physically hold, even if all blocks were free.  The task must be
         terminated (evicted).
     """
+
     OK = auto()
     CONGESTED = auto()
     EXCEEDS_CAPACITY = auto()

--- a/chitu/task.py
+++ b/chitu/task.py
@@ -776,10 +776,8 @@ class BatchResult:
 class TaskPool:
     """Global registry of all active (running + waiting) tasks on this rank.
 
-    Only rank 0 populates the pool; other ranks receive task metadata via
-    ZMQ dispatchers.  Tasks are stored in a dict keyed by ``task_id`` for O(1)
-    lookup, with an ordered ``id_list`` that preserves arrival order for
-    deterministic FCFS scheduling.
+    Tasks are stored in a dict keyed by ``task_id`` for O(1) lookup, with an
+    ordered ``id_list`` for deterministic iteration.
 
     The ``pending_queue`` holds tasks that have been submitted by the router
     but not yet promoted into the main pool (e.g. during a concurrent decode

--- a/chitu/task.py
+++ b/chitu/task.py
@@ -93,8 +93,20 @@ class RequestParams:
 
 @dataclass
 class UserRequest:
-    """
-    Request object holding context for processing input request
+    """Incoming inference request with full lifecycle state.
+
+    A UserRequest encapsulates everything the server needs to process one
+    conversation turn: the prompt tokens, sampling parameters, tool-call
+    configuration, and streaming output buffer (``AsyncDataStream``).
+
+    Lifecycle:
+    1. Created from a client request via ``from_request_params`` (parse, tokenize,
+       apply chat template, build grammar for tool calls).
+    2. Wrapped in a ``Task`` for scheduling.
+    3. Receives generated tokens via ``add_data()``, which pushes into the
+       async stream for delivery to the client.
+    4. ``stop_stream()`` marks the request complete and optionally writes
+       a trace file.
     """
 
     # ============ Serialization fields ==============
@@ -345,6 +357,20 @@ class UserRequest:
 
 
 class Task:
+    """A schedulable unit of inference work — one request going through prefill → decode.
+
+    Tasks are the bridge between the scheduler and the executor.  They carry all
+    the metadata the scheduler needs for admission decisions (prefix cache
+    locality, DP rank assignment, KV cache block allocation) and all the state
+    the executor needs to run the forward pass (token buffers, chunk boundaries,
+    MTP acceptance indices).
+
+    Lifecycle:
+    - Created in ``TaskType.Prefill`` state.
+    - After prefill completes (``consume_req_tokens()``), transitions to ``TaskType.Decode``.
+    - Stopped when EOS is emitted, max_new_tokens is reached, or KV cache overflows.
+    """
+
     def __init__(
         self,
         task_id: str,
@@ -748,6 +774,18 @@ class BatchResult:
 
 
 class TaskPool:
+    """Global registry of all active (running + waiting) tasks on this rank.
+
+    Only rank 0 populates the pool; other ranks receive task metadata via
+    ZMQ dispatchers.  Tasks are stored in a dict keyed by ``task_id`` for O(1)
+    lookup, with an ordered ``id_list`` that preserves arrival order for
+    deterministic FCFS scheduling.
+
+    The ``pending_queue`` holds tasks that have been submitted by the router
+    but not yet promoted into the main pool (e.g. during a concurrent decode
+    step).
+    """
+
     pool: dict[str, Task] = {}
     id_list: list[str] = []
     pending_queue: deque[Task] = Deque()
@@ -908,6 +946,21 @@ class PackedTasksBase:
 
 
 class PackedTasks(PackedTasksBase):
+    """A batch of tasks ready for model execution, constructed from task IDs.
+
+    PackedTasks is created by rank 0 from the scheduler output and serialized
+    (via ``MetadataSerializer``) for ZMQ dispatch to all TP/PP/DP ranks.
+    It pre-computes everything the executor needs:
+
+    - Token lists (for prefill) or next-token indices (for decode).
+    - KV cache block assignments (``new_cache_ids_list``).
+    - Prefix cache hit metadata (``inc_hit_tokens_list``).
+    - Multimodal payloads (pixel values and grid dimensions for VL models).
+
+    When ``metadata_only`` is True, the object carries only metadata fields
+    (no tensor data), used for DP worker ranks that just need task descriptors.
+    """
+
     def __init__(
         self,
         task_ids: list[str],

--- a/chitu/task.py
+++ b/chitu/task.py
@@ -95,13 +95,13 @@ class RequestParams:
 class UserRequest:
     """Incoming inference request with full lifecycle state.
 
-    A UserRequest encapsulates everything the server needs to process one
-    conversation turn: the prompt tokens, sampling parameters, tool-call
+    A UserRequest encapsulates the server-side state needed to process one
+    conversation turn: prompt tokens, sampling parameters, tool-call
     configuration, and streaming output buffer (``AsyncDataStream``).
 
     Lifecycle:
     1. Created from a client request via ``from_request_params`` (parse, tokenize,
-       apply chat template, build grammar for tool calls).
+       apply chat template, and store tool-call configuration when enabled).
     2. Wrapped in a ``Task`` for scheduling.
     3. Receives generated tokens via ``add_data()``, which pushes into the
        async stream for delivery to the client.
@@ -367,7 +367,8 @@ class Task:
 
     Lifecycle:
     - Created in ``TaskType.Prefill`` state.
-    - After prefill completes (``consume_req_tokens()``), transitions to ``TaskType.Decode``.
+    - After all prompt tokens have been consumed by ``consume_req_tokens()``,
+      transitions to ``TaskType.Decode``.
     - Stopped when request stop conditions are met or the scheduler evicts it.
     """
 

--- a/chitu/task.py
+++ b/chitu/task.py
@@ -357,7 +357,7 @@ class UserRequest:
 
 
 class Task:
-    """A schedulable unit of inference work — one request going through prefill → decode.
+    """A schedulable unit of inference work — one request going through prefill -> decode.
 
     Tasks are the bridge between the scheduler and the executor.  They carry all
     the metadata the scheduler needs for admission decisions (prefix cache
@@ -368,7 +368,7 @@ class Task:
     Lifecycle:
     - Created in ``TaskType.Prefill`` state.
     - After prefill completes (``consume_req_tokens()``), transitions to ``TaskType.Decode``.
-    - Stopped when EOS is emitted, max_new_tokens is reached, or KV cache overflows.
+    - Stopped when request stop conditions are met or the scheduler evicts it.
     """
 
     def __init__(


### PR DESCRIPTION
Add docstrings and inline comments to key files explaining the architecture and logic of the Chitu inference engine:

- chitu_main.py: main loop, warmup, KV cache auto-resize
- executor.py: step execution, TP/PP/DP/CP dispatchers, sampling
- scheduler.py: scheduling policies, KV cache capacity management
- backend.py: distributed init, model loading, checkpoint loading
- models/model.py: Transformer base class, prefill/decode
- task.py: UserRequest, Task, TaskPool, PackedTasks
- kv_cache/: PagedKVCache, DenseKVCache, CacheManager
- moe/impl.py: MoE dispatch (Gate/Dispatch/Expert/Combine)
- attn_backend/base.py: attention backend interface