### PR TITLE
Fix logprobs handling when top_logprobs is omitted

### DIFF
--- a/chitu/async_stream.py
+++ b/chitu/async_stream.py
@@ -50,7 +50,7 @@ class AsyncDataStream:
                 return
             s = self.tokenizer.decode(self.cache_tokens)
             top_tokens = (
-                [self.tokenizer.decode(token_idx) for token_idx in top_token_idx]
+                [self.tokenizer.decode([token_idx]) for token_idx in top_token_idx]
                 if top_token_idx
                 else None
             )

--- a/chitu/executor.py
+++ b/chitu/executor.py
@@ -2339,10 +2339,12 @@ class Executor:
                     batch_result.logprobs[it],
                     batch_result.token_idxs[it],
                 )
-                logprobs_list.append(logprobs[: max(1, task.req.top_logprobs)].tolist())
-                token_idxs_list.append(
-                    token_idxs[: max(1, task.req.top_logprobs)].tolist()
-                )
+                num_logprobs = task.req.top_logprobs
+                if num_logprobs is None:
+                    num_logprobs = 1
+                num_logprobs = max(1, num_logprobs)
+                logprobs_list.append(logprobs[:num_logprobs].tolist())
+                token_idxs_list.append(token_idxs[:num_logprobs].tolist())
         self.get_token_sink().emit_batch(
             batch_result.tasks, next_token_list, logprobs_list, token_idxs_list
         )

--- a/chitu/serve/openai_api.py
+++ b/chitu/serve/openai_api.py
@@ -305,7 +305,10 @@ class AsyncResponse:
                                     "top_logprobs": [],
                                 }
                             )
-                            if self.req.top_logprobs > 0:
+                            if (
+                                self.req.top_logprobs is not None
+                                and self.req.top_logprobs > 0
+                            ):
                                 for logprob, token in zip(top_logprobs, top_tokens):
                                     logprobs["content"][-1]["top_logprobs"].append(
                                         {
@@ -412,7 +415,7 @@ class AsyncResponse:
                         "top_logprobs": [],
                     }
                 )
-                if self.req.top_logprobs > 0:
+                if self.req.top_logprobs is not None and self.req.top_logprobs > 0:
                     for logprob, token in zip(top_logprobs, top_tokens):
                         logprobs["content"][-1]["top_logprobs"].append(
                             {

--- a/test/pytest/test_logprobs_response.py
+++ b/test/pytest/test_logprobs_response.py
@@ -104,7 +104,7 @@ def test_executor_accepts_omitted_top_logprobs():
         tasks=[task],
         tokens=[[2]],
         return_logprobs=True,
-        logprobs=torch.tensor([[-0.1, -0.2]]),
+        logprobs=torch.tensor([[-0.1, -0.2]], dtype=torch.bfloat16),
         token_idxs=torch.tensor([[2, 3]]),
     )
     sink = RecordingTokenSink()
@@ -115,7 +115,7 @@ def test_executor_accepts_omitted_top_logprobs():
 
     assert sink.task_list == [task]
     assert sink.token_list == [[2]]
-    assert sink.logprobs_list[0] == pytest.approx([-0.1])
+    assert sink.logprobs_list == [[batch_result.logprobs[0, 0].item()]]
     assert sink.token_idxs_list == [[2]]
 
 

--- a/test/pytest/test_logprobs_response.py
+++ b/test/pytest/test_logprobs_response.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2025 Qingcheng.AI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from chitu.async_stream import AsyncDataStream
+from chitu.executor import Executor
+from chitu.serve.openai_api import AsyncResponse
+
+
+class SequenceTokenizer:
+    force_full_seq_decode = False
+
+    def decode(self, token_ids):
+        assert isinstance(token_ids, list)
+        return "".join(str(token_id) for token_id in token_ids)
+
+
+class StaticAsyncStream:
+    def __init__(self, items):
+        self.items = list(items)
+        self.tokens_len = len(self.items)
+        self.index = 0
+        self.reasoning_parser = SimpleNamespace(
+            params=SimpleNamespace(enable_reasoning=False)
+        )
+
+    def __aiter__(self):
+        self.index = 0
+        return self
+
+    async def __anext__(self):
+        if self.index >= len(self.items):
+            raise StopAsyncIteration
+        item = self.items[self.index]
+        self.index += 1
+        return item
+
+
+class RecordingTokenSink:
+    def emit_batch(
+        self, task_list, token_list, logprobs_list=None, token_idxs_list=None
+    ):
+        self.task_list = task_list
+        self.token_list = token_list
+        self.logprobs_list = logprobs_list
+        self.token_idxs_list = token_idxs_list
+
+
+def make_data_stream():
+    stream = AsyncDataStream.__new__(AsyncDataStream)
+    stream.tokenizer = SequenceTokenizer()
+    stream.seqs = []
+    stream.tokens_len = 0
+    stream.chars_len = 0
+    stream.cache_tokens = []
+    stream.stop_signal = False
+    stream.lock = threading.Lock()
+    stream.data_event = asyncio.Event()
+    stream.top_logprobs_list = []
+    stream.top_tokens_list = []
+    stream.reasoning_parser = SimpleNamespace(update=lambda token_id: False)
+    stream.reasoning_states = []
+    stream.cached_reasoning_state = False
+    stream.callbacks_on_stop = []
+    stream.error_message = None
+    return stream
+
+
+def make_response(top_logprobs=None):
+    async_stream = StaticAsyncStream([("2", False, ([-0.1], ["2"]))])
+    req = SimpleNamespace(
+        request_id="req-logprobs",
+        async_stream=async_stream,
+        tool_call_params=None,
+        logprobs=True,
+        top_logprobs=top_logprobs,
+        finish_reason="stop",
+        output="2",
+        prompt_len=1,
+        num_hit_tokens=0,
+    )
+    return AsyncResponse(req)
+
+
+def test_top_logprob_tokens_are_decoded_as_sequences():
+    stream = make_data_stream()
+
+    stream.add_data(1, [-0.1], [2], notify_server=False)
+
+    assert stream.top_tokens_list == [["2"]]
+
+
+def test_executor_accepts_omitted_top_logprobs():
+    task = SimpleNamespace(req=SimpleNamespace(top_logprobs=None))
+    batch_result = SimpleNamespace(
+        tasks=[task],
+        tokens=[[2]],
+        return_logprobs=True,
+        logprobs=torch.tensor([[-0.1, -0.2]]),
+        token_idxs=torch.tensor([[2, 3]]),
+    )
+    sink = RecordingTokenSink()
+    executor = Executor.__new__(Executor)
+    executor.get_token_sink = lambda: sink
+
+    executor.postprocess_async_part(batch_result)
+
+    assert sink.task_list == [task]
+    assert sink.token_list == [[2]]
+    assert sink.logprobs_list[0] == pytest.approx([-0.1])
+    assert sink.token_idxs_list == [[2]]
+
+
+@pytest.mark.parametrize(
+    "top_logprobs, expected_count",
+    [(None, 0), (0, 0), (-1, 0), (1, 1)],
+)
+def test_stream_response_handles_top_logprobs(top_logprobs, expected_count):
+    async def collect_chunks():
+        return [
+            chunk
+            async for chunk in make_response(top_logprobs).stream_generator(
+                include_usage=False
+            )
+        ]
+
+    chunks = asyncio.run(collect_chunks())
+    response = json.loads(chunks[0].removeprefix("data: ").strip())
+
+    response_top_logprobs = response["choices"][0]["logprobs"]["content"][0][
+        "top_logprobs"
+    ]
+    assert len(response_top_logprobs) == expected_count
+
+
+@pytest.mark.parametrize(
+    "top_logprobs, expected_count",
+    [(None, 0), (0, 0), (-1, 0), (1, 1)],
+)
+def test_full_response_handles_top_logprobs(top_logprobs, expected_count):
+    response = asyncio.run(make_response(top_logprobs).full_generator())
+
+    response_top_logprobs = response.choices[0]["logprobs"]["content"][0][
+        "top_logprobs"
+    ]
+    assert len(response_top_logprobs) == expected_count


### PR DESCRIPTION
## Summary

- pass top-logprob token IDs to the tokenizer as one-element sequences
- keep one logprob entry internally when `top_logprobs` is omitted
- handle omitted `top_logprobs` in streamed and non-streamed responses without changing zero or negative values
- add regression coverage for the executor and both response paths

## Validation

- `pytest -q test/pytest/test_logprobs_response.py test/pytest/test_openai_api_params.py test/pytest/test_async_pp_dp_result_pairing.py`: 89 passed
- the new regression file on `public-main`: 4 failed and 6 passed, reproducing the failures covered by this patch
- the same regression file on this branch: 10 passed
- `black --check` on the four changed Python files
- `python -m compileall -q` on the four changed Python files
- `git diff --check origin/public-main...HEAD`
- full suite smoke run: 163 passed and 16 skipped before an unrelated Triton FP8 test stopped on RTX 3090 because `fp8e4nv` is unsupported

Fixes #135