### PR TITLE
Return HTTP 400 for oversized chat prompts

### DIFF
--- a/chitu/serve/openai_api.py
+++ b/chitu/serve/openai_api.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime
 from logging import getLogger
 from typing import Annotated, Any, Optional, Literal, Mapping
+from fastapi import HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -21,7 +22,7 @@ DOC_GENERATION = os.environ.get("CHITU_GENERATING_DOCS") == "1"
 
 if not DOC_GENERATION:
     from chitu.global_vars import get_global_args
-    from chitu.task import UserRequest, RequestParams
+    from chitu.task import PromptTooLongError, UserRequest, RequestParams
     from chitu.serve.common import (
         set_min_batch_size,
         submit_request,
@@ -495,8 +496,11 @@ async def handle_chat_completion(
 ):
 
     args = get_global_args()
+    try:
+        user_req = build_user_request(request, priority)
+    except PromptTooLongError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     set_min_batch_size(request.min_batch_size)
-    user_req = build_user_request(request, priority)
     await submit_request(user_req)
     rsp = AsyncResponse(user_req)
 

--- a/chitu/task.py
+++ b/chitu/task.py
@@ -43,6 +43,10 @@ from chitu.sampling.utils import submit_grammar_compile
 logger = getLogger(__name__)
 
 
+class PromptTooLongError(ValueError):
+    """Raised when a prompt is too long for an inference request."""
+
+
 class TaskStatus(Enum):
     Stopped = -1
     AvailableForSchedule = 0
@@ -245,7 +249,7 @@ class UserRequest:
     def cap_max_new_tokens(max_new_tokens: int, prompt_len: int) -> int:
         max_seq_len = get_global_args().infer.max_seq_len
         if prompt_len >= max_seq_len:
-            raise ValueError(
+            raise PromptTooLongError(
                 f"prompt length({prompt_len}) cannot be greater than max_seq_len({max_seq_len})"
             )
         max_new_tokens = min(max_new_tokens, max_seq_len - prompt_len + 1)

--- a/test/pytest/test_api_server_openai.py
+++ b/test/pytest/test_api_server_openai.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import chitu.serve.api_server as api_server
+import chitu.serve.api_app as api_app
+import chitu.serve.common as serve_common
+import chitu.serve.middleware as serve_middleware
+import chitu.serve.openai_api as openai_api
+import chitu.task as task
+import chitu.tool_call.utils as tool_call_utils
+
+
+class DummyFormatter:
+    def encode_dialog_prompt(self, messages, chat_template_kwargs):
+        return [1, 2, 3, 4, 5]
+
+
+async def unexpected_submit_request(_request):
+    raise AssertionError("oversized request reached submit_request")
+
+
+def create_client(monkeypatch):
+    args = SimpleNamespace(
+        infer=SimpleNamespace(max_seq_len=4, max_concurrent_requests=None),
+        debug=SimpleNamespace(save_trace_dir=None),
+        models=SimpleNamespace(name="test-model"),
+        serve=SimpleNamespace(api_keys=[], validate_api_key=False),
+    )
+    monkeypatch.setattr(api_server.Backend, "formatter", DummyFormatter())
+    monkeypatch.setattr(task, "get_global_args", lambda: args)
+    monkeypatch.setattr(openai_api, "get_global_args", lambda: args)
+    monkeypatch.setattr(serve_common, "get_global_args", lambda: args)
+    monkeypatch.setattr(serve_middleware, "get_global_args", lambda: args)
+    monkeypatch.setattr(api_app, "get_server_status", lambda: True)
+    monkeypatch.setattr(serve_common, "min_batch_size", 1)
+    monkeypatch.setattr(
+        task,
+        "update_chat_template_kwargs_reasoning",
+        lambda kwargs, enable_thinking: None,
+    )
+    monkeypatch.setattr(
+        tool_call_utils,
+        "get_tool_parser_cls",
+        lambda: tool_call_utils.DummyToolParser,
+    )
+    monkeypatch.setattr(
+        openai_api,
+        "submit_request",
+        unexpected_submit_request,
+    )
+    return TestClient(api_server.app, raise_server_exceptions=False)
+
+
+def post_chat_completion(client):
+    return client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "too long"}],
+            "max_tokens": 1,
+            "min_batch_size": 7,
+        },
+    )
+
+
+def test_oversized_chat_prompt_returns_bad_request(monkeypatch):
+    client = create_client(monkeypatch)
+
+    response = post_chat_completion(client)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "prompt length(5) cannot be greater than max_seq_len(4)"
+    }
+    assert serve_common.min_batch_size == 1
+
+
+def test_internal_value_error_remains_server_error(monkeypatch):
+    client = create_client(monkeypatch)
+
+    def raise_internal_error(request, priority):
+        raise ValueError("internal failure")
+
+    monkeypatch.setattr(openai_api, "build_user_request", raise_internal_error)
+
+    response = post_chat_completion(client)
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "internal failure"}


### PR DESCRIPTION
Fixes #136

When the prompt length was at least `max_seq_len`, the chat endpoint raised a plain `ValueError`, which the generic exception handler returned as HTTP 500

This change uses a dedicated exception for the prompt-length check and maps it to HTTP 400 only in the chat completion handler. Unrelated `ValueError`s still return HTTP 500

Request construction now happens before `set_min_batch_size()`, so a rejected prompt cannot change scheduler state

The reproduction used a 5-token prompt with `max_seq_len=4`

On `public-main` at `2c946b6a`:

- `stream=false`: HTTP 500
- `stream=true`: HTTP 500

On this branch:

- `stream=false`: HTTP 400
- `stream=true`: HTTP 400
- `submit_request()` calls: 0
- `min_batch_size`: unchanged

Tests:

```text
python -m pytest -q test/pytest/test_api_server_openai.py test/pytest/test_api_server_responses.py test/pytest/test_api_server_tokenize.py test/pytest/test_openai_api_params.py test/pytest/test_responses_api_params.py test/pytest/test_anthropic_api_params.py
```

`216 passed`
